### PR TITLE
Maintain joystick haptics while binding macros

### DIFF
--- a/main.py
+++ b/main.py
@@ -288,11 +288,19 @@ class InputManager:
         self.active: bool = False
         self.allowed_devices: List[str] = []
         self.safe_mode: bool = False
+        self.haptics: Dict[int, Any] = {}
+        self.haptics_enabled: bool = False
 
         if HAS_PYGAME:
             try:
                 pygame.init()
                 pygame.joystick.init()
+                if hasattr(pygame, "haptic"):
+                    try:
+                        pygame.haptic.init()
+                        self.haptics_enabled = pygame.haptic.get_init()
+                    except Exception as e:
+                        print(f"[InputManager] Pygame haptics init error: {e}")
                 threading.Thread(target=self._input_loop, daemon=True).start()
             except Exception as e:
                 print(f"[InputManager] Pygame init error: {e}")
@@ -309,6 +317,7 @@ class InputManager:
             if HAS_PYGAME:
                 try:
                     pygame.quit()
+                    self.haptics.clear()
                 except Exception:
                     pass
         else:
@@ -318,6 +327,9 @@ class InputManager:
                         pygame.init()
                     if not pygame.joystick.get_init():
                         pygame.joystick.init()
+                    if hasattr(pygame, "haptic") and not pygame.haptic.get_init():
+                        pygame.haptic.init()
+                        self.haptics_enabled = pygame.haptic.get_init()
                 except Exception as e:
                     print(f"[InputManager] Error reactivating pygame: {e}")
 
@@ -330,18 +342,21 @@ class InputManager:
         """
         if self.safe_mode or not HAS_PYGAME:
             return []
-            
+
         try:
-            pygame.joystick.quit()
-            pygame.joystick.init()
+            if not pygame.get_init():
+                pygame.init()
+            if not pygame.joystick.get_init():
+                pygame.joystick.init()
             devices = []
             count = pygame.joystick.get_count()
-            
+
             for i in range(count):
                 try:
                     j = pygame.joystick.Joystick(i)
+                    if not j.get_init():
+                        j.init()
                     devices.append((i, j.get_name()))
-                    j.quit()
                 except Exception:
                     devices.append((i, f"Device {i} (Error)"))
                     
@@ -362,10 +377,16 @@ class InputManager:
 
         self.joysticks.clear()
         self.allowed_devices = list(allowed_names)
+        self.haptics.clear()
 
         try:
-            pygame.joystick.quit()
-            pygame.joystick.init()
+            if not pygame.get_init():
+                pygame.init()
+            if not pygame.joystick.get_init():
+                pygame.joystick.init()
+            if hasattr(pygame, "haptic") and not pygame.haptic.get_init():
+                pygame.haptic.init()
+                self.haptics_enabled = pygame.haptic.get_init()
 
             for i in range(pygame.joystick.get_count()):
                 j = pygame.joystick.Joystick(i)
@@ -373,11 +394,36 @@ class InputManager:
                     try:
                         j.init()
                         self.joysticks.append(j)
+                        self._attach_haptic(j)
                         print(f"[InputManager] Connected: {j.get_name()}")
                     except Exception:
                         pass
         except Exception:
             pass
+
+    def _attach_haptic(self, joystick):
+        """Ensure a haptic device is opened for the given joystick."""
+        if not self.haptics_enabled:
+            return
+
+        try:
+            jid = joystick.get_id()
+            if jid in self.haptics:
+                return
+
+            haptic = pygame.haptic.Haptic(jid)
+            haptic.open(jid)
+
+            try:
+                if hasattr(haptic, "rumble_init"):
+                    haptic.rumble_init()
+            except Exception:
+                pass
+
+            self.haptics[jid] = haptic
+        except Exception:
+            # If haptic setup fails, keep joystick input alive but skip force feedback binding
+            self.haptics.pop(joystick.get_id(), None)
 
     def _input_loop(self):
         """Background loop to capture joystick events."""


### PR DESCRIPTION
## Summary
- initialize and retain pygame haptics so joystick force feedback stays active while bound to macros
- avoid unnecessary joystick subsystem resets and reattach haptic handles when allowed devices are connected

## Testing
- python -m compileall main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f03e6dd248333bff18e6b94a3c538)