### PR TITLE
Handle missing Vosk DLL during import

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,9 +140,15 @@ else:
 try:
     import vosk
     HAS_VOSK = True
-except ImportError:
+    _VOSK_IMPORT_ERROR = ""
+except (ImportError, FileNotFoundError, OSError) as exc:
     vosk = None
     HAS_VOSK = False
+    _VOSK_IMPORT_ERROR = str(exc)
+    print(
+        "Warning: 'vosk' could not be loaded (offline recognition disabled):"
+        f" {_VOSK_IMPORT_ERROR}"
+    )
 
 # ======================================================================
 # GLOBAL CONFIGURATION
@@ -5001,6 +5007,8 @@ class iRacingControlApp:
             return "Using Windows speech recognizer"
 
         if not HAS_VOSK:
+            if _VOSK_IMPORT_ERROR:
+                return f"Vosk unavailable: {_VOSK_IMPORT_ERROR}"
             return "Vosk not installed"
 
         model_path = self.vosk_model_path.get()


### PR DESCRIPTION
## Summary
- catch Vosk import errors (including missing DLLs) so the app keeps running in bundled builds
- log the import failure and surface the error in the voice engine status message

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f9d878f9083339a0ce4ba20dfb43f)