### PR TITLE
Add Whisper GPU-enabled voice recognition option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyttsx3>=2.90
 pyaudio>=0.2.14
 SpeechRecognition>=3.10.0
 vosk>=0.3.45
+faster-whisper>=1.0.0


### PR DESCRIPTION
## Summary
- add optional Whisper (faster-whisper) engine support to the voice listener with auto device selection
- expose Whisper model selection/status in the voice/audio settings alongside existing Vosk controls
- persist Whisper configuration and include faster-whisper in the dependencies

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69408333d6f8832a91a676a04e2e6f14)