### PR TITLE
Improve Vosk DLL path detection

### DIFF
--- a/FINAL OK.py
+++ b/FINAL OK.py
@@ -109,6 +109,20 @@ warnings.filterwarnings(
 def _prepare_vosk_env() -> Optional[str]:
     """Ensure Vosk DLLs are discoverable when running a bundled executable."""
 
+    def _contains_vosk_binaries(path: str) -> bool:
+        """Return True if the directory holds plausible Vosk binaries."""
+
+        if not os.path.isdir(path):
+            return False
+
+        expected_names = {"vosk.dll", "libvosk.dll", "libvosk.so", "libvosk.dylib"}
+        for name in os.listdir(path):
+            lower_name = name.lower()
+            if lower_name in expected_names or lower_name.startswith("libvosk"):
+                return True
+
+        return False
+
     candidates = []
 
     # Explicit overrides take precedence
@@ -134,7 +148,11 @@ def _prepare_vosk_env() -> Optional[str]:
 
     selected: Optional[str] = None
     for path in candidates:
-        if not path or not os.path.isdir(path):
+        if not path:
+            continue
+
+        # Only use the path if it looks like it actually contains the DLLs.
+        if not _contains_vosk_binaries(path):
             continue
 
         selected = path


### PR DESCRIPTION
## Summary
- ensure Vosk DLL search only uses directories that actually include Vosk binaries
- avoid selecting temporary bundle directories without Vosk libraries to prevent noisy import errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694097391f8c8333ae2ca9d5e65bb515)