### PR TITLE
Document Whisper voice model setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,21 @@ Each tab includes:
 - **Output Device:** Choose an audio device if PyAudio is installed; falls back to default otherwise.
 - **Voice Selection:** Uses the first available English voice; customize via OS voice settings.
 
-### 8) Voice Control with Vosk
-1. Install dependencies (`vosk`, `SpeechRecognition`, `pyaudio`).
-2. Download an English model from the [Vosk releases](https://alphacephei.com/vosk/models) (e.g., `vosk-model-small-en-us-0.15`).
-3. Extract the model folder somewhere convenient (e.g., `C:\vosk\vosk-model-small-en-us-0.15`).
-4. In the app settings, set the **Vosk model path** to that folder and enable **Voice Commands**.
-5. Speak commands like “Brake bias up,” “Traction control preset two,” or custom phrases you bind in the voice settings panel.
-6. Use a quiet environment or a push-to-talk input to reduce false triggers.
+### 8) Voice Control (Vosk or Whisper)
+- **Vosk (fast/small footprint):**
+  1. Install dependencies (`vosk`, `SpeechRecognition`, `pyaudio`).
+  2. Download an English model from the [Vosk releases](https://alphacephei.com/vosk/models) (e.g., `vosk-model-small-en-us-0.15`).
+  3. Extract the model folder somewhere convenient (e.g., `C:\vosk\vosk-model-small-en-us-0.15`).
+  4. In the app settings, set the **Vosk model path** to that folder and enable **Voice Commands**.
+
+- **Whisper (higher accuracy, optional GPU):**
+  1. Install the bundled dependency `faster-whisper` (in `requirements.txt`).
+  2. Download a CTranslate2 Whisper model from [Hugging Face](https://huggingface.co/collections/Systran/faster-whisper-655b5dd2959f16f30bdd5e23) (e.g., **tiny**, **base**, or **small**) and extract it (e.g., `C:\whisper\faster-whisper-small`).
+  3. In the app, choose **Whisper** as the voice engine, click **Select Whisper model folder**, and point to the extracted folder.
+  4. Enable **Voice Commands** and test phrases like “Brake bias up” or your custom bindings.
+  5. For best performance, pick the smallest model that recognizes your accent reliably; GPU users can try **medium** or **large-v2**.
+
+General tips: use a quiet environment or push-to-talk to reduce false triggers, and keep the model paths on a fast local drive.
 
 ### 9) Saving & Profiles
 - **Save Current:** Stores car+track specific bindings, HUD state, timing profile, presets, combos, and Vosk settings.

--- a/docs/guides/install_guide.md
+++ b/docs/guides/install_guide.md
@@ -36,13 +36,22 @@ This guide walks through installing Dominant Control, enabling every option, and
 7. **Timing profile:** select Aggressive, Casual, Relaxed, or configure **Custom** press/hold timings.
 8. **Save profile:** enter car and track names and click **Save Current**. Profiles auto-load on match.
 
-## 4. Vosk Voice Command Setup
-1. Install voice dependencies (already in `requirements.txt`): `vosk`, `SpeechRecognition`, `pyaudio`.
+## 4. Voice Command Engines (Vosk or Whisper)
+You can run voice commands with either Vosk (lightweight) or Whisper (higher accuracy, can use GPU). Install dependencies from `requirements.txt` first.
+
+### A) Vosk Setup (CPU-friendly)
+1. Install voice dependencies: `vosk`, `SpeechRecognition`, `pyaudio`.
 2. Download a Vosk English model (e.g., `vosk-model-small-en-us-0.15`) from [alphacephei.com/vosk/models](https://alphacephei.com/vosk/models).
 3. Extract the model folder to a stable path (e.g., `C:\vosk\vosk-model-small-en-us-0.15`).
-4. In the app settings, set **Vosk model path** to the extracted folder.
+4. In the app settings, set **Vosk model path** to the extracted folder and pick **Vosk** as the voice engine.
 5. Enable **Voice Commands** and test phrases like “Brake bias up” or “Traction control preset two.”
-6. Use a quieter environment or push-to-talk if background noise triggers commands.
+
+### B) Whisper Setup (accuracy-focused, optional GPU)
+1. Ensure `faster-whisper` is installed (included in `requirements.txt`).
+2. Download a CTranslate2 Whisper model from the [faster-whisper collection](https://huggingface.co/collections/Systran/faster-whisper-655b5dd2959f16f30bdd5e23) — start with **tiny**/**base** for CPU or **small**/**medium**/**large-v2** if you have GPU headroom.
+3. Extract the model folder somewhere stable (e.g., `C:\whisper\faster-whisper-small`). The folder should contain `model.bin` and tokenizer files.
+4. In the app, set the voice engine to **Whisper**, click **Select Whisper model folder**, and point to the extracted folder.
+5. Enable **Voice Commands** and test your phrases. If recognition lags, try a smaller model or keep the model on a faster drive.
 
 ## 5. Feature-by-Feature Guide
 - **CONFIG / RUNNING Modes:** configure in CONFIG, drive in RUNNING. The mode button clearly shows the active state.

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -51,12 +51,19 @@ In **HUD / Overlay**, select which variables to show, adjust colors/font/opacity
 **How do I enable TTS?**  
 Turn on TTS in settings. If PyAudio is installed you can choose an output device; otherwise system default is used.
 
-**How do I set up Vosk voice commands?**  
-1) Install `vosk`, `SpeechRecognition`, and `pyaudio` (already in `requirements.txt`).  
-2) Download a model from [Vosk releases](https://alphacephei.com/vosk/models) and extract it.  
-3) Set the **Vosk model path** to the extracted folder.  
-4) Enable **Voice Commands** and test phrases like “Brake bias up” or “Traction control preset two.”  
+**How do I set up Vosk voice commands?**
+1) Install `vosk`, `SpeechRecognition`, and `pyaudio` (already in `requirements.txt`).
+2) Download a model from [Vosk releases](https://alphacephei.com/vosk/models) and extract it.
+3) Set the **Vosk model path** to the extracted folder and select **Vosk** as the engine.
+4) Enable **Voice Commands** and test phrases like “Brake bias up” or “Traction control preset two.”
 5) For noisy rooms, use push-to-talk or a smaller model to reduce false triggers.
+
+**How do I use Whisper instead of Vosk?**
+1) Ensure `faster-whisper` is installed (bundled in `requirements.txt`).
+2) Download a CTranslate2 Whisper model from the [Hugging Face faster-whisper collection](https://huggingface.co/collections/Systran/faster-whisper-655b5dd2959f16f30bdd5e23) (e.g., tiny/base/small for CPU; medium/large-v2 if you have GPU headroom).
+3) Extract the model folder so it contains `model.bin` and tokenizer files (e.g., `C:\whisper\faster-whisper-small`).
+4) In the app, pick **Whisper** as the voice engine, click **Select Whisper model folder**, and point to the extracted directory.
+5) Enable **Voice Commands** and test your phrases. If recognition lags, switch to a smaller model or place the model on a faster drive.
 
 ## Troubleshooting
 **The app can’t connect to iRacing.**  


### PR DESCRIPTION
## Summary
- add Whisper setup guidance alongside Vosk in the main README
- expand the install guide with Vosk and Whisper model download/configuration steps
- update the FAQ with Whisper voice engine usage notes and tips

## Testing
- Not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69409a4aff2c83338a9d29c84f5e9310)