### PR TITLE
Prevent restart loop after session scan

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -3517,6 +3517,7 @@ class iRacingControlApp:
         self.scans_since_restart = 0
         self.pending_scan_on_start = False
         self.skip_race_restart_once = False
+        self.skip_session_scan_once = False
         self._last_auto_pair: Tuple[str, str] = ("", "")
         self._session_scan_pending = False
 
@@ -4666,6 +4667,10 @@ class iRacingControlApp:
                 self.skip_race_restart_once = False
                 return False
 
+            if self.skip_session_scan_once:
+                self.skip_session_scan_once = False
+                return False
+
             if self.auto_restart_on_race.get() and new_type == "Race":
                 self.pending_scan_on_start = True
                 mark_pending_scan()
@@ -5170,6 +5175,7 @@ class iRacingControlApp:
         """Execute a deferred scan request set before restarting."""
         if consume_pending_scan():
             self.pending_scan_on_start = True
+            self.skip_session_scan_once = True
 
         if self.pending_scan_on_start:
             self.skip_race_restart_once = True


### PR DESCRIPTION
### Motivation
- A pending rescan marker caused the app to immediately re-trigger a session scan on restart, creating a restart loop when sessions advanced.
- The change prevents the automatic session-triggered rescan from firing once immediately after a restart-triggered pending scan.

### Description
- Added a one-shot flag `skip_session_scan_once` to the app state in `FINALOK.py` to track a single skipped session scan.
- Set `skip_session_scan_once` when consuming the persisted pending-scan marker via `consume_pending_scan` inside `_perform_pending_scan`.
- Updated `_handle_session_change` to honor `skip_session_scan_once` and avoid scheduling the session scan when set.
- Changes are localized to `FINALOK.py` and preserve existing `save_config`/pending-scan semantics.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b3f9ec518833394905ad3a0655914)