### PR TITLE
Timing profiles: per-profile customization UI and BOT press_ms set to 20ms

### DIFF
--- a/dominant_control/config.py
+++ b/dominant_control/config.py
@@ -28,15 +28,59 @@ DEFAULT_OVERLAY_FEEDBACK: Dict[str, Any] = {
     "cooldown_s": 6.0,
 }
 
+DEFAULT_TIMING_PROFILES: Dict[str, Dict[str, Any]] = {
+    "aggressive": {
+        "press_min_ms": 10,
+        "press_max_ms": 10,
+        "interval_min_ms": 10,
+        "interval_max_ms": 10,
+        "random_enabled": False,
+        "random_range_ms": 10,
+    },
+    "casual": {
+        "press_min_ms": 80,
+        "press_max_ms": 80,
+        "interval_min_ms": 100,
+        "interval_max_ms": 100,
+        "random_enabled": False,
+        "random_range_ms": 10,
+    },
+    "relaxed": {
+        "press_min_ms": 150,
+        "press_max_ms": 150,
+        "interval_min_ms": 200,
+        "interval_max_ms": 200,
+        "random_enabled": False,
+        "random_range_ms": 10,
+    },
+    "bot": {
+        "press_min_ms": 20,
+        "press_max_ms": 20,
+        "interval_min_ms": 20,
+        "interval_max_ms": 20,
+        "random_enabled": False,
+        "random_range_ms": 10,
+    },
+    "custom": {
+        "press_min_ms": 60,
+        "press_max_ms": 80,
+        "interval_min_ms": 60,
+        "interval_max_ms": 90,
+        "random_enabled": False,
+        "random_range_ms": 10,
+    },
+}
+
 GLOBAL_TIMING: Dict[str, Any] = {
     "profile": "aggressive",  # "aggressive", "casual", "relaxed", "custom", "bot"
-    # Custom profile settings:
-    "press_min_ms": 60,
-    "press_max_ms": 80,
-    "interval_min_ms": 60,
-    "interval_max_ms": 90,
-    "random_enabled": False,
-    "random_range_ms": 10,
+    "profile_customized": {
+        profile: profile == "custom"
+        for profile in DEFAULT_TIMING_PROFILES
+    },
+    "profile_settings": {
+        profile: settings.copy()
+        for profile, settings in DEFAULT_TIMING_PROFILES.items()
+    },
 }
 
 TTS_STATE: Dict[str, Any] = {
@@ -158,6 +202,7 @@ __all__ = [
     "BASE_PATH",
     "CONFIG_FILE",
     "CONFIG_FOLDER",
+    "DEFAULT_TIMING_PROFILES",
     "DEFAULT_OVERLAY_FEEDBACK",
     "GLOBAL_TIMING",
     "ICON_CANDIDATES",

--- a/dominant_control/input_engine.py
+++ b/dominant_control/input_engine.py
@@ -6,7 +6,7 @@ import random
 import time
 from typing import Any, Dict, Optional, Tuple
 
-from .config import GLOBAL_TIMING
+from .config import DEFAULT_TIMING_PROFILES, GLOBAL_TIMING
 
 IS_WINDOWS = os.name == "nt" and hasattr(ctypes, "windll")
 
@@ -112,21 +112,76 @@ def _normalize_timing_config(timing: Dict[str, Any]) -> Dict[str, Any]:
     if normalized.get("profile") not in allowed_profiles:
         normalized["profile"] = "aggressive"
 
-    for key in [
-        "press_min_ms",
-        "press_max_ms",
-        "interval_min_ms",
-        "interval_max_ms",
-        "random_range_ms",
-    ]:
-        try:
-            normalized[key] = max(1, int(normalized.get(key, GLOBAL_TIMING[key])))
-        except (TypeError, ValueError, KeyError):
-            normalized[key] = GLOBAL_TIMING.get(key, 10)
+    profile_settings: Dict[str, Dict[str, Any]] = {}
+    raw_profiles = normalized.get("profile_settings", {})
+    legacy_custom = {
+        "press_min_ms": normalized.get("press_min_ms"),
+        "press_max_ms": normalized.get("press_max_ms"),
+        "interval_min_ms": normalized.get("interval_min_ms"),
+        "interval_max_ms": normalized.get("interval_max_ms"),
+        "random_enabled": normalized.get("random_enabled"),
+        "random_range_ms": normalized.get("random_range_ms"),
+    }
+    legacy_has_values = any(value is not None for value in legacy_custom.values())
 
-    normalized["random_enabled"] = bool(normalized.get("random_enabled", False))
+    for profile, defaults in DEFAULT_TIMING_PROFILES.items():
+        merged = dict(defaults)
+        raw_profile = {}
+        if isinstance(raw_profiles, dict):
+            raw_profile = raw_profiles.get(profile, {}) or {}
+        if not isinstance(raw_profile, dict):
+            raw_profile = {}
+        merged.update(raw_profile)
+        if profile == "custom" and legacy_has_values:
+            for key, value in legacy_custom.items():
+                if value is not None:
+                    merged[key] = value
+
+        for key in [
+            "press_min_ms",
+            "press_max_ms",
+            "interval_min_ms",
+            "interval_max_ms",
+            "random_range_ms",
+        ]:
+            try:
+                merged[key] = max(1, int(merged.get(key, defaults[key])))
+            except (TypeError, ValueError, KeyError):
+                merged[key] = defaults.get(key, 10)
+
+        merged["random_enabled"] = bool(
+            merged.get("random_enabled", defaults.get("random_enabled", False))
+        )
+        profile_settings[profile] = merged
+
+    raw_customized = normalized.get("profile_customized", {})
+    profile_customized: Dict[str, bool] = {}
+    for profile in DEFAULT_TIMING_PROFILES:
+        default_customized = profile == "custom" and legacy_has_values
+        if isinstance(raw_customized, dict):
+            profile_customized[profile] = bool(
+                raw_customized.get(profile, default_customized)
+            )
+        else:
+            profile_customized[profile] = default_customized
+
+    normalized["profile_settings"] = profile_settings
+    normalized["profile_customized"] = profile_customized
 
     return normalized
+
+
+def _effective_profile_settings(
+    timing_cfg: Dict[str, Any], profile: str
+) -> Dict[str, Any]:
+    """Return the timing settings for the active profile."""
+
+    profile_settings = timing_cfg.get("profile_settings", {})
+    profile_customized = timing_cfg.get("profile_customized", {})
+    if profile_customized.get(profile, False):
+        return profile_settings.get(profile, DEFAULT_TIMING_PROFILES[profile])
+
+    return DEFAULT_TIMING_PROFILES[profile]
 
 
 def _compute_timing(is_float: bool = False) -> Tuple[float, float]:
@@ -135,30 +190,18 @@ def _compute_timing(is_float: bool = False) -> Tuple[float, float]:
     timing_cfg = _normalize_timing_config(GLOBAL_TIMING)
     profile = timing_cfg.get("profile", "aggressive")
 
-    if profile == "aggressive":
-        press_ms = 10
-        interval_ms = 10
-    elif profile == "casual":
-        press_ms = 80
-        interval_ms = 100
-    elif profile == "relaxed":
-        press_ms = 150
-        interval_ms = 200
-    elif profile == "bot":
-        press_ms = 1
-        interval_ms = 1
-    else:  # custom
-        p_min = timing_cfg.get("press_min_ms", 60)
-        p_max = timing_cfg.get("press_max_ms", 80)
-        i_min = timing_cfg.get("interval_min_ms", 60)
-        i_max = timing_cfg.get("interval_max_ms", 90)
-        press_ms = random.uniform(p_min, p_max)
-        interval_ms = random.uniform(i_min, i_max)
+    settings = _effective_profile_settings(timing_cfg, profile)
+    p_min = settings.get("press_min_ms", 60)
+    p_max = settings.get("press_max_ms", 80)
+    i_min = settings.get("interval_min_ms", 60)
+    i_max = settings.get("interval_max_ms", 90)
+    press_ms = random.uniform(p_min, p_max)
+    interval_ms = random.uniform(i_min, i_max)
 
-        if timing_cfg.get("random_enabled", False):
-            rng = timing_cfg.get("random_range_ms", 10)
-            press_ms += random.uniform(-rng, rng)
-            interval_ms += random.uniform(-rng, rng)
+    if settings.get("random_enabled", False):
+        rng = settings.get("random_range_ms", 10)
+        press_ms += random.uniform(-rng, rng)
+        interval_ms += random.uniform(-rng, rng)
 
     min_value = 1 if profile == "bot" else 10
     press_ms = max(min_value, press_ms)

--- a/dominant_control/ui/timing_window.py
+++ b/dominant_control/ui/timing_window.py
@@ -5,7 +5,8 @@ from typing import Callable
 import tkinter as tk
 from tkinter import messagebox, ttk
 
-from dominant_control.config import GLOBAL_TIMING
+from dominant_control.config import DEFAULT_TIMING_PROFILES, GLOBAL_TIMING
+from dominant_control.input_engine import _normalize_timing_config
 
 
 class GlobalTimingWindow(tk.Toplevel):
@@ -71,10 +72,10 @@ class GlobalTimingWindow(tk.Toplevel):
             command=self._on_profile_change
         ).pack(anchor="w", padx=5, pady=(2, 5))
 
-        # Custom settings
+        # Profile settings
         self.custom_frame = tk.LabelFrame(
             timing_frame,
-            text="Custom Settings (this profile only)"
+            text="Profile Settings"
         )
         self.custom_frame.pack(fill="x", padx=10, pady=10)
 
@@ -83,40 +84,26 @@ class GlobalTimingWindow(tk.Toplevel):
         )
         self.entry_press_min = tk.Entry(self.custom_frame, width=8)
         self.entry_press_min.grid(row=0, column=1, padx=5, pady=2)
-        self.entry_press_min.insert(
-            0, str(GLOBAL_TIMING.get("press_min_ms", 60))
-        )
 
         tk.Label(self.custom_frame, text="Press Max (ms):").grid(
             row=0, column=2, sticky="w", padx=5, pady=2
         )
         self.entry_press_max = tk.Entry(self.custom_frame, width=8)
         self.entry_press_max.grid(row=0, column=3, padx=5, pady=2)
-        self.entry_press_max.insert(
-            0, str(GLOBAL_TIMING.get("press_max_ms", 80))
-        )
 
         tk.Label(self.custom_frame, text="Interval Min (ms):").grid(
             row=1, column=0, sticky="w", padx=5, pady=2
         )
         self.entry_interval_min = tk.Entry(self.custom_frame, width=8)
         self.entry_interval_min.grid(row=1, column=1, padx=5, pady=2)
-        self.entry_interval_min.insert(
-            0, str(GLOBAL_TIMING.get("interval_min_ms", 60))
-        )
 
         tk.Label(self.custom_frame, text="Interval Max (ms):").grid(
             row=1, column=2, sticky="w", padx=5, pady=2
         )
         self.entry_interval_max = tk.Entry(self.custom_frame, width=8)
         self.entry_interval_max.grid(row=1, column=3, padx=5, pady=2)
-        self.entry_interval_max.insert(
-            0, str(GLOBAL_TIMING.get("interval_max_ms", 90))
-        )
 
-        self.var_random = tk.BooleanVar(
-            value=GLOBAL_TIMING.get("random_enabled", False)
-        )
+        self.var_random = tk.BooleanVar()
         self.check_random = tk.Checkbutton(
             self.custom_frame,
             text="Randomize (humanize)",
@@ -132,9 +119,23 @@ class GlobalTimingWindow(tk.Toplevel):
         )
         self.entry_random_range = tk.Entry(self.custom_frame, width=8)
         self.entry_random_range.grid(row=3, column=1, padx=5, pady=2)
-        self.entry_random_range.insert(
-            0, str(GLOBAL_TIMING.get("random_range_ms", 10))
+
+        self.var_customize = tk.BooleanVar()
+        self.check_customize = tk.Checkbutton(
+            self.custom_frame,
+            text="Customize this profile",
+            variable=self.var_customize,
+            command=self._toggle_customize
         )
+        self.check_customize.grid(
+            row=4, column=0, columnspan=2, sticky="w", padx=5, pady=(5, 2)
+        )
+
+        tk.Button(
+            self.custom_frame,
+            text="Reset to Defaults",
+            command=self._reset_profile_defaults
+        ).grid(row=4, column=2, columnspan=2, sticky="e", padx=5, pady=(5, 2))
 
         for i in range(4):
             self.custom_frame.columnconfigure(i, weight=1)
@@ -153,7 +154,36 @@ class GlobalTimingWindow(tk.Toplevel):
     def _on_profile_change(self):
         """Handle profile selection change."""
         profile = self.var_profile.get()
-        state = "normal" if profile == "custom" else "disabled"
+        timing_cfg = _normalize_timing_config(GLOBAL_TIMING)
+        customized = timing_cfg.get("profile_customized", {}).get(profile, False)
+        defaults = DEFAULT_TIMING_PROFILES.get(profile, {})
+        settings = timing_cfg.get("profile_settings", {}).get(profile, defaults)
+        values = settings if customized else defaults
+
+        self.var_customize.set(customized)
+        self._set_entry_value(self.entry_press_min, values.get("press_min_ms", 0))
+        self._set_entry_value(self.entry_press_max, values.get("press_max_ms", 0))
+        self._set_entry_value(
+            self.entry_interval_min, values.get("interval_min_ms", 0)
+        )
+        self._set_entry_value(
+            self.entry_interval_max, values.get("interval_max_ms", 0)
+        )
+        self.var_random.set(values.get("random_enabled", False))
+        self._set_entry_value(
+            self.entry_random_range, values.get("random_range_ms", 0)
+        )
+
+        self._toggle_customize()
+
+    def _set_entry_value(self, entry: tk.Entry, value: int) -> None:
+        entry.delete(0, tk.END)
+        entry.insert(0, str(value))
+
+    def _toggle_customize(self):
+        """Enable customization only when checked."""
+        enabled = self.var_customize.get()
+        state = "normal" if enabled else "disabled"
 
         for widget in [
             self.entry_press_min,
@@ -161,48 +191,79 @@ class GlobalTimingWindow(tk.Toplevel):
             self.entry_interval_min,
             self.entry_interval_max,
             self.check_random,
-            self.entry_random_range
+            self.entry_random_range,
         ]:
             widget.config(state=state)
+
+        if not enabled:
+            self._apply_default_values()
+
+        self._toggle_random()
+
+    def _apply_default_values(self) -> None:
+        profile = self.var_profile.get()
+        defaults = DEFAULT_TIMING_PROFILES.get(profile, {})
+        self._set_entry_value(self.entry_press_min, defaults.get("press_min_ms", 0))
+        self._set_entry_value(self.entry_press_max, defaults.get("press_max_ms", 0))
+        self._set_entry_value(
+            self.entry_interval_min, defaults.get("interval_min_ms", 0)
+        )
+        self._set_entry_value(
+            self.entry_interval_max, defaults.get("interval_max_ms", 0)
+        )
+        self.var_random.set(defaults.get("random_enabled", False))
+        self._set_entry_value(
+            self.entry_random_range, defaults.get("random_range_ms", 0)
+        )
 
     def _toggle_random(self):
         """Handle randomization toggle."""
         state = (
             "normal"
-            if self.var_random.get() and self.var_profile.get() == "custom"
+            if self.var_random.get() and self.var_customize.get()
             else "disabled"
         )
         self.entry_random_range.config(state=state)
+
+    def _reset_profile_defaults(self):
+        """Reset current profile to default values."""
+        self.var_customize.set(False)
+        self._apply_default_values()
+        self._toggle_customize()
 
     def save_all(self):
         """Save timing configuration."""
         profile = self.var_profile.get()
         GLOBAL_TIMING["profile"] = profile
 
-        if profile == "custom":
+        customized = self.var_customize.get()
+        GLOBAL_TIMING.setdefault("profile_customized", {})
+        GLOBAL_TIMING.setdefault("profile_settings", {})
+        GLOBAL_TIMING["profile_customized"][profile] = customized
+
+        settings = DEFAULT_TIMING_PROFILES.get(profile, {}).copy()
+        if customized:
             try:
-                GLOBAL_TIMING["press_min_ms"] = int(
-                    self.entry_press_min.get()
-                )
-                GLOBAL_TIMING["press_max_ms"] = int(
-                    self.entry_press_max.get()
-                )
-                GLOBAL_TIMING["interval_min_ms"] = int(
+                settings["press_min_ms"] = int(self.entry_press_min.get())
+                settings["press_max_ms"] = int(self.entry_press_max.get())
+                settings["interval_min_ms"] = int(
                     self.entry_interval_min.get()
                 )
-                GLOBAL_TIMING["interval_max_ms"] = int(
+                settings["interval_max_ms"] = int(
                     self.entry_interval_max.get()
                 )
-                GLOBAL_TIMING["random_enabled"] = self.var_random.get()
-                GLOBAL_TIMING["random_range_ms"] = int(
+                settings["random_enabled"] = self.var_random.get()
+                settings["random_range_ms"] = int(
                     self.entry_random_range.get()
                 )
             except ValueError:
                 messagebox.showerror(
                     "Error",
-                    "Please use numbers only in Custom mode."
+                    "Please use numbers only in Customize mode."
                 )
                 return
+
+        GLOBAL_TIMING["profile_settings"][profile] = settings
 
         self.callback(GLOBAL_TIMING)
         self.destroy()


### PR DESCRIPTION
### Motivation
- Increase the BOT press duration and expose timing values so users can view and tune timings per profile.
- Allow per-profile customization that the user can enable/disable and provide a way to reset a profile back to defaults.
- Persist configurable profile settings so timing changes are applied by the input engine.

### Description
- Introduced `DEFAULT_TIMING_PROFILES` and extended `GLOBAL_TIMING` with `profile_settings` and `profile_customized` in `config.py` and set the BOT `press_ms` default to `20`.
- Reworked timing normalization and computation in `input_engine.py` to read per-profile settings, provide legacy config migration, and use `_effective_profile_settings` when computing timings via `_compute_timing`.
- Updated the timing UI in `ui/timing_window.py` to display profile values, add a `Customize this profile` checkbox, a `Reset to Defaults` button, and persist per-profile settings in `save_all`.
- Kept `save_all` callback behavior intact while moving custom values into `GLOBAL_TIMING['profile_settings']` and storing `profile_customized` flags.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b46546a4c8333b01f69c9deaf3e13)