### PR TITLE
Disable scan popup and enable autosave by default

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -3599,8 +3599,8 @@ class iRacingControlApp:
         self.auto_restart_on_rescan = tk.BooleanVar(value=True)
         self.auto_restart_on_race = tk.BooleanVar(value=True)
         self.keep_trying_targets = tk.BooleanVar(value=True)
-        self.show_scan_popup = tk.BooleanVar(value=True)
-        self.auto_save_presets = tk.BooleanVar(value=False)
+        self.show_scan_popup = tk.BooleanVar(value=False)
+        self.auto_save_presets = tk.BooleanVar(value=True)
         self.clear_target_bind: Optional[str] = None
         self.btn_clear_target_bind: Optional[tk.Button] = None
         self.voice_phrase_map: Dict[str, Callable] = {}
@@ -5351,9 +5351,9 @@ class iRacingControlApp:
         self.auto_detect.set(data.get("auto_detect", True))
         self.auto_restart_on_rescan.set(data.get("auto_restart_on_rescan", True))
         self.auto_restart_on_race.set(data.get("auto_restart_on_race", True))
-        self.auto_save_presets.set(data.get("auto_save_presets", False))
+        self.auto_save_presets.set(data.get("auto_save_presets", True))
         self.keep_trying_targets.set(data.get("keep_trying_targets", True))
-        self.show_scan_popup.set(data.get("show_scan_popup", True))
+        self.show_scan_popup.set(data.get("show_scan_popup", False))
         self.clear_target_bind = data.get("clear_target_bind")
         self.pending_scan_on_start = data.get("pending_scan_on_start", False)
 


### PR DESCRIPTION
### Motivation
- Ensure the app defaults are more user-friendly by disabling the scan completion popup and enabling preset auto-save.
- Keep the aggressive input timing profile as the default behavior for input simulation.
- Align persisted config fallback values with the updated UI defaults so newly created configs reflect the intended defaults.

### Description
- Set `show_scan_popup` initial UI variable to `False` and `auto_save_presets` to `True` in `iRacingControlApp.__init__` of `FINALOK.py`.
- Update `load_config` to use `data.get("auto_save_presets", True)` and `data.get("show_scan_popup", False)` so saved/loaded defaults match the UI defaults.
- No other behavioral changes were made; this is strictly a defaults/config alignment change in `FINALOK.py`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b4ccf67d48333998f890d7e9da6dc)