### PR TITLE
Improve auto scan detection for car/track changes

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -4588,6 +4588,7 @@ class iRacingControlApp:
             self.auto_detect.get()
             or self.auto_restart_on_race.get()
             or self.auto_scan_on_change.get()
+            or self.auto_restart_on_rescan.get()
         ):
             self.root.after(2000, self.auto_preset_loop)
             return
@@ -4605,7 +4606,11 @@ class iRacingControlApp:
             if self._handle_session_change(session_type, session_num):
                 return
 
-            if not (self.auto_detect.get() or self.auto_scan_on_change.get()):
+            if not (
+                self.auto_detect.get()
+                or self.auto_scan_on_change.get()
+                or self.auto_restart_on_rescan.get()
+            ):
                 self.root.after(2000, self.auto_preset_loop)
                 return
 
@@ -4636,6 +4641,9 @@ class iRacingControlApp:
                 c for c in raw_track
                 if c.isalnum() or c in " -_"
             )
+            if not car_clean.strip() or not track_clean.strip():
+                self.root.after(2000, self.auto_preset_loop)
+                return
 
             current_pair = (car_clean, track_clean)
 
@@ -4646,7 +4654,7 @@ class iRacingControlApp:
 
                 if self.auto_detect.get():
                     self.auto_fill_ui(car_clean, track_clean)
-                if self.auto_scan_on_change.get():
+                if self.auto_scan_on_change.get() or self.auto_restart_on_rescan.get():
                     self._schedule_session_scan()
                 if telemetry_reconnected:
                     self._schedule_session_scan()


### PR DESCRIPTION
### Motivation
- The auto-detect loop could exit prematurely when restart-on-rescan was enabled, preventing continuous telemetry reads and reliable auto-restarts.
- The app sometimes acted on incomplete telemetry (missing car or track), causing false or missed scans and restarts.
- Session scans should also be triggered when restart-on-rescan is enabled so rescans occur consistently on car/track changes.
- Make the detection loop more robust across telemetry reconnects and restarts.

### Description
- Kept the auto-detect loop running when `auto_restart_on_rescan` is enabled by adding it to the early-exit conditions in `auto_preset_loop` in `FINALOK.py`.
- Added a guard to skip scheduling work until both detected `car` and `track` strings are non-empty so scans do not trigger on partial telemetry.
- When a new car/track pair is observed, the code now schedules a session scan if either `auto_scan_on_change` or `auto_restart_on_rescan` is enabled by calling `self._schedule_session_scan()`.
- All changes are localized to the `auto_preset_loop` behavior in `FINALOK.py` and preserve existing preset skeleton creation and persistence logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b55da25388333a7984f6e309f2cfb)