### PR TITLE
Fix rescan restart suppression on session changes

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -4827,11 +4827,13 @@ class iRacingControlApp:
                 or self.current_track
             ).strip()
             restart_pair = (restart_car, restart_track)
-            if not (
-                restart_car
-                and restart_track
-                and restart_pair == self._rescan_restart_pair
-            ):
+            detected_pair = (detected_car, detected_track)
+            suppress_restart = (
+                detected_car
+                and detected_track
+                and detected_pair == self._rescan_restart_pair
+            )
+            if not suppress_restart:
                 self.pending_scan_on_start = True
                 if restart_car and restart_track:
                     self._rescan_restart_pair = restart_pair


### PR DESCRIPTION
### Motivation
- Prevent the auto-rescan restart suppression from blocking legitimate rescans when the session's car/track changes.
- The previous logic could compare a persisted restart pair against a restart candidate built from fallback values when telemetry was stale, causing spurious suppression.
- Only suppress auto-restart when the current car/track can be detected from telemetry and matches the stored pair.

### Description
- In `scan_driver_controls` (in `FINALOK.py`) compute `detected_pair` and a `suppress_restart` flag and only suppress the restart when both `detected_car` and `detected_track` are present and equal to `self._rescan_restart_pair`.
- Retain the existing behavior of setting `self._rescan_restart_pair`, marking a pending scan, saving config, and calling `restart_program` when a restart is allowed.
- The change is a small conditional refactor that prevents stale/missing telemetry from blocking session-change rescans.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b58ae987c8333b602679a5d5809a7)