### PR TITLE
Reset auto-detect pairing on telemetry reconnect

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -4777,6 +4777,7 @@ class iRacingControlApp:
             self._mark_session_inactive()
             return False
 
+        self._last_auto_pair = ("", "")
         self.auto_load_attempted.clear()
         return True
 


### PR DESCRIPTION
### Motivation
- The app could fail to detect a new car/track pair when starting a fresh session because the previously auto-detected pair remained cached across telemetry reconnects.
- That stale `_last_auto_pair` prevented the auto-detection logic from recognizing a change and triggering UI updates or scans.
- The intent is to force a fresh auto-detect cycle when telemetry becomes active again so new sessions are correctly recognized.

### Description
- Reset `self._last_auto_pair` to `("", "")` when telemetry transitions to active in `_set_telemetry_active` to force re-evaluation of the current pair.
- The change is a single-line addition in `FINALOK.py` inside the `iRacingControlApp._set_telemetry_active` method.
- This preserves existing session-inactive handling and only clears the cached auto-detect pair on reconnect.

### Testing
- No automated tests were run for this change.
- The change is limited to a single assignment and was committed to `FINALOK.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b5c7762c08333a4a1e74367332f0d)