### PR TITLE
Fix auto-detect reconnect on new iRacing sessions

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -4600,8 +4600,19 @@ class iRacingControlApp:
             with self.ir_lock:
                 if not getattr(self.ir, "is_initialized", False):
                     self.ir.startup()
+                elif getattr(self.ir, "is_connected", True) is False:
+                    try:
+                        self.ir.shutdown()
+                    except Exception:
+                        pass
+                    self.ir.startup()
+                    self._refresh_controller_ir()
 
             if not getattr(self.ir, "is_initialized", False):
+                self.root.after(2000, self.auto_preset_loop)
+                return
+            if getattr(self.ir, "is_connected", True) is False:
+                self._set_telemetry_active(False)
                 self.root.after(2000, self.auto_preset_loop)
                 return
 


### PR DESCRIPTION
### Motivation
- Auto-detect was not updating when starting a new iRacing session because the SDK handle could be `is_initialized` but not `is_connected`.
- Controller objects kept a stale `ir` handle and did not reflect a renewed connection.
- Telemetry state was not being marked inactive when the SDK connection remained down, preventing retries.

### Description
- In `auto_preset_loop` (in `FINALOK.py`) reconnect the SDK when `is_initialized` is true but `is_connected` is false by calling `shutdown()` then `startup()` and refreshing controllers via `_refresh_controller_ir()`.
- After the initialization check, bail early when `is_connected` is false and mark telemetry inactive with `_set_telemetry_active(False)` so the loop will retry later.
- Keep other auto-detect behavior intact (auto-fill, session scans, and preset skeleton creation).

### Testing
- No automated tests were run for this change.
- No unit or integration test results to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b61f95ad88333abd6050f4a8fb14b)