### PR TITLE
Fix float detection for driver control scan

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -4980,7 +4980,10 @@ class iRacingControlApp:
                 if not isinstance(value, numbers.Real):
                     continue
 
-                is_float = (float(value) % 1.0) != 0.0
+                is_float = (
+                    isinstance(value, numbers.Real)
+                    and not isinstance(value, numbers.Integral)
+                )
                 found_vars.append((candidate, is_float))
 
         except Exception as e:


### PR DESCRIPTION
### Motivation
- The driver-control scan could misclassify float-capable variables (e.g., brake bias) when the current value happened to be a whole number, causing the app to treat them as integers.
- Detecting float capability based on the fractional part is unreliable when the SDK returns a whole-valued reading for a float variable.
- Classify variables by numeric type instead of value shape to reliably detect float-capable `dc*` controls.

### Description
- Change the float-detection logic in the scan loop to compute `is_float` via `isinstance(value, numbers.Real) and not isinstance(value, numbers.Integral)`.
- Keep the existing numeric filtering that skips `bool` and non-`numbers.Real` values before the float/type check.
- Modified file: `FINALOK.py` (scan code that builds `found_vars` / `active_vars`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695b64d210bc8333ac3d49bb1e62c67a)