### PR TITLE
Expose `tk.Widget` alias in PyQt6 tkinter shim

### DIFF
--- a/FINALOK_PyQt6.py
+++ b/FINALOK_PyQt6.py
@@ -892,6 +892,7 @@ class _TtkNamespace:
 tk = _TkNamespace()
 tk.Tk = Tk
 tk.Toplevel = Toplevel
+tk.Widget = TkWidgetBase
 tk.Frame = Frame
 tk.LabelFrame = LabelFrame
 tk.Label = Label


### PR DESCRIPTION
### Motivation
- Resolve the `AttributeError: '_TkNamespace' object has no attribute 'Widget'` triggered by type annotations like `parent: tk.Widget`.
- Provide the expected tkinter surface by exposing `TkWidgetBase` as `tk.Widget` so annotations and runtime lookups succeed.
- Keep the PyQt6-based tkinter shim compatible with code that imports or type-hints against `tk.Widget`.

### Description
- Add the assignment `tk.Widget = TkWidgetBase` to `FINALOK_PyQt6.py` alongside the other `tk` attribute assignments.
- This change maps the shim's base widget class to the `tk.Widget` name so type hints and attribute accesses resolve correctly.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c0b79cfb48333a91bb12dbb820b88)