### PR TITLE
Add Windows setup batch script to install Python and dependencies

### DIFF
--- a/setup_finalok.bat
+++ b/setup_finalok.bat
@@ -1,0 +1,57 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo === FINALOK setup ===
+echo This will install Python (if needed) and required packages.
+echo.
+
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%"
+
+where py >nul 2>&1
+if %errorlevel% neq 0 (
+  echo Python launcher not found. Attempting to install Python via winget...
+  where winget >nul 2>&1
+  if %errorlevel% neq 0 (
+    echo ERROR: winget is not available. Please install Python 3.11+ manually.
+    echo Download from: https://www.python.org/downloads/windows/
+    popd
+    exit /b 1
+  )
+  winget install -e --id Python.Python.3.11 --accept-source-agreements --accept-package-agreements
+  if %errorlevel% neq 0 (
+    echo ERROR: Python installation failed.
+    popd
+    exit /b 1
+  )
+)
+
+where py >nul 2>&1
+if %errorlevel% neq 0 (
+  echo ERROR: Python launcher still not found after install.
+  popd
+  exit /b 1
+)
+
+echo.
+echo Upgrading pip...
+py -3 -m pip install --upgrade pip
+if %errorlevel% neq 0 (
+  echo ERROR: Failed to upgrade pip.
+  popd
+  exit /b 1
+)
+
+echo.
+echo Installing requirements...
+py -3 -m pip install -r requirements.txt
+if %errorlevel% neq 0 (
+  echo ERROR: Failed to install requirements.
+  popd
+  exit /b 1
+)
+
+echo.
+echo Setup complete. You can now run FINALOK.py.
+popd
+endlocal


### PR DESCRIPTION
### Motivation
- Provide an easy one-click setup for users who do not have Python so they can run `FINALOK.py`.
- Automate installation of the project dependencies listed in `requirements.txt`.
- Attempt to install Python via `winget` when a `py` launcher is missing and otherwise give guidance for manual install.
- Surface clear error messages and basic checks to help non-technical users recover from common failures.

### Description
- Add `setup_finalok.bat` which runs from the repository directory and verifies the presence of the `py` launcher.
- If `py` is missing the script attempts to install Python 3.11 using `winget install -e --id Python.Python.3.11`.
- The script upgrades pip using `py -3 -m pip install --upgrade pip` and installs dependencies via `py -3 -m pip install -r requirements.txt`.
- The script includes basic error handling and prints guidance when `winget` is not available or when steps fail.

### Testing
- No automated tests were run because the script is Windows-specific.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c0cc86ca4833381e826009ebe49be)