### PR TITLE
Fix tk.Widget annotation fallback

### DIFF
--- a/FINALOK_PyQt6.py
+++ b/FINALOK_PyQt6.py
@@ -882,7 +882,7 @@ class _FileDialog:
 
 
 class _TkNamespace:
-    pass
+    Widget = TkWidgetBase
 
 
 class _TtkNamespace:


### PR DESCRIPTION
### Motivation
- Importing the PyQt6->tkinter compatibility layer raised `AttributeError: '_TkNamespace' object has no attribute 'Widget'` when annotations like `parent: tk.Widget` were evaluated.
- The crash occurred at class definition time because the `_TkNamespace` class did not expose a `Widget` attribute.
- The change aims to make the compatibility shim robust so type annotations referencing `tk.Widget` do not fail.
- Keep the fix minimal and non-invasive to preserve existing `tk` mappings.

### Description
- Add `Widget = TkWidgetBase` to the `_TkNamespace` class to provide a fallback for annotations.
- This ensures `tk.Widget` is available when annotations are evaluated, avoiding the `AttributeError`.
- The rest of the `tk` instance mappings remain unchanged and continue to assign concrete widget classes.
- The change is a single-line, localized update in `FINALOK_PyQt6.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c0c6cd02883338156e08e1e83200d)