### PR TITLE
Align control preset columns and add joystick icon to Controls tab

### DIFF
--- a/FINALOK (33).py
+++ b/FINALOK (33).py
@@ -2745,7 +2745,7 @@ class ControlTab(tk.Frame):
         tk.Label(
             header,
             text="Macro value",
-            width=10,
+            width=8,
             anchor="w",
             font=("Arial", 8, "bold")
         ).pack(side="left", padx=5)
@@ -2759,7 +2759,7 @@ class ControlTab(tk.Frame):
         tk.Label(
             header,
             text="Voice trigger phrase",
-            width=20,
+            width=18,
             anchor="w",
             font=("Arial", 8, "bold")
         ).pack(side="left", padx=5)
@@ -3866,7 +3866,7 @@ class iRacingControlApp:
         setup_tab = ttk.Frame(main_tabs)
         controls_tab = ttk.Frame(main_tabs)
         main_tabs.add(setup_tab, text="Setup")
-        main_tabs.add(controls_tab, text="Controls")
+        main_tabs.add(controls_tab, text="🎮 Controls")
 
         setup_container = tk.Frame(setup_tab)
         setup_container.pack(fill="both", expand=True, padx=5, pady=5)

--- a/FINALOKYPT.py
+++ b/FINALOKYPT.py
@@ -2746,7 +2746,7 @@ class ControlTab(tk.Frame):
         tk.Label(
             header,
             text="Valor da macro",
-            width=10,
+            width=8,
             anchor="w",
             font=("Arial", 8, "bold")
         ).pack(side="left", padx=5)
@@ -2760,7 +2760,7 @@ class ControlTab(tk.Frame):
         tk.Label(
             header,
             text="Frase de gatilho por voz",
-            width=20,
+            width=18,
             anchor="w",
             font=("Arial", 8, "bold")
         ).pack(side="left", padx=5)


### PR DESCRIPTION
### Motivation
- Improve alignment of preset/macro header labels with their entry fields in the Controls UI for clearer layout. 
- Provide a clearer visual affordance for the Controls tab by adding a joystick icon. 
- Keep localized UI layouts consistent (English and Portuguese). 
- This is a cosmetic/UI-only change to improve usability.

### Description
- Reduced the header column widths for the presets/macro rows from `width=10` to `width=8` and `width=20` to `width=18` to match entry field sizes in `ControlTab`.
- Applied the same header width adjustments in the localized file `FINALOKYPT.py` to keep parity across translations.
- Updated the main tab label to include a joystick emoji by changing the Controls tab text to `"🎮 Controls"` in `FINALOK (33).py`.
- Changes are limited to `FINALOK (33).py` and `FINALOKYPT.py` (UI layout only).

### Testing
- No automated tests were executed for this change (UI-only modifications). 
- Verified changes via a local `git diff` and committed the two modified files. 
- No unit or integration tests were added or run as part of this PR. 
- Manual UI verification is recommended when running the application to confirm alignment and tab label appearance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e1e2044b88333809ea43e6d23b770)