### PR TITLE
Speed up `bot` timing profile to 1ms press/interval

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -553,8 +553,8 @@ def _compute_timing(is_float: bool = False) -> Tuple[float, float]:
         press_ms = 150
         interval_ms = 200
     elif profile == "bot":
-        press_ms = 20
-        interval_ms = 10
+        press_ms = 1
+        interval_ms = 1
     else:  # custom
         p_min = timing_cfg.get("press_min_ms", 60)
         p_max = timing_cfg.get("press_max_ms", 80)


### PR DESCRIPTION
### Motivation
- Make the `bot` behavior profile as fast as physically possible for key actuation and computer input simulation.
- Improve responsiveness for the experimental/robotic profile used by probes and automated adjustments.

### Description
- Change in `_compute_timing` (in `FINALOK.py`) sets `press_ms` and `interval_ms` for the `bot` profile to `1` ms each.
- Existing safeguards remain in place via the `min_value` enforcement and the float-variable extra delay logic.
- No other timing profiles or features were modified.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e2958741c83338d15a91b2d5c10ad)