### PR TITLE
Auto-size Timing Adjustments window so SAVE button is visible

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -3611,6 +3611,12 @@ class GlobalTimingWindow(tk.Toplevel):
             height=2
         ).pack(fill="x", padx=10, pady=10)
 
+        self.update_idletasks()
+        min_width = max(420, self.winfo_reqwidth())
+        min_height = self.winfo_reqheight()
+        self.minsize(min_width, min_height)
+        self.geometry(f"{min_width}x{min_height}")
+
         self._on_profile_change()
         self._profile_initialized = True
 


### PR DESCRIPTION
### Motivation
- The Timing Adjustments dialog could be too small on some displays, hiding the bottom `SAVE` button and forcing users to manually resize the window. 
- Make the timing window size itself to its content so controls (especially the save action) are always reachable.

### Description
- In `GlobalTimingWindow.__init__` (in `FINALOK.py`) call `self.update_idletasks()` to finalize widget layout before measuring sizes.  
- Compute `min_width = max(420, self.winfo_reqwidth())` and `min_height = self.winfo_reqheight()` and apply them via `self.minsize(...)` and `self.geometry(...)`.  
- This ensures the window is at least the original width but expands to fit required widgets so the `💾 SAVE` button is visible.

### Testing
- No automated tests were executed for this change.  
- Manual interactive verification was implied by the change (not recorded as an automated test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e2e491bb48333b0e29ff09b57d4ea)