### PR TITLE
Improve Quick Start guide readability and spacing

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -2,10 +2,15 @@
 
 Get running in minutes with Dominant Control.
 
+Use the sections below as a checklist. Each step has breathing room so you can scan quickly and come back later.
+
 ## Before You Begin
 - Windows 10/11 (64-bit)
+
 - iRacing installed and an active subscription
+
 - (Source install) Python 3.10+ with dependencies from `requirements.txt`
+
 - Start the app **before** iRacing if you use controllers; or use **Keyboard Only Mode**.
 
 ## 1) Install & Launch
@@ -26,9 +31,13 @@ Get running in minutes with Dominant Control.
 1. In the app, switch to **CONFIG** mode (button in the title bar).
 2. Follow the guided steps in **Step 1–3** to pick car/track, confirm devices, and scan controls.
 3. For each tab:
+
    - Click **Set Increase (+)** and press your desired key/button.
+
    - Click **Set Decrease (-)** and press your desired key/button.
+
    - Add up to four **Presets** by typing a value and binding a key/button.
+
    - Toggle HUD visibility for that variable if desired.
 
 ## 4) HUD / Overlay Setup
@@ -39,16 +48,20 @@ Get running in minutes with Dominant Control.
 
 ## 5) Combos & Timing
 - **⚡ Combos Tab:** create macros that set multiple controls at once (e.g., “Rain” or “Pit Exit”). Bind to a single key/button.
+
 - **Timing Profiles:** pick Aggressive / Casual / Relaxed or create a **Custom** profile if adjustments fire too slowly/quickly.
 
 ## 6) Voice & Audio Feedback
 - Open **Options → Voice/Audio Settings** to configure engines, devices, and tuning.
+
 - **Text-to-Speech:** enable in settings for spoken confirmations; choose an output device if PyAudio is available.
+
 - **Vosk Voice Commands:**
   1. Download a Vosk English model and note its folder path.
   2. Set the **Vosk model path** and enable **Voice Commands**.
   3. Test phrases like “Brake bias up” or “Traction control preset two.”
   4. Use a push-to-talk key if your room is noisy.
+
 - **whisper.cpp (offline):**
   1. Download a whisper.cpp build and a GGML/GGUF model file.
   2. Select the whisper.cpp executable and model in **Voice/Audio Settings**.
@@ -61,12 +74,16 @@ Get running in minutes with Dominant Control.
 
 ## 8) Maintenance
 - Profiles live in `%APPDATA%\DominantControl\configs\`; back them up before reinstalling.
+
 - After updates, re-verify bindings, HUD layout, timing profile, and Vosk model path.
 
 ## Common Fixes
 - **No telemetry:** be in Drive mode and rescan controls.
+
 - **Force feedback loss:** start Dominant Control before iRacing or use Keyboard Only Mode.
+
 - **HUD missing:** toggle overlay visibility and drag it back on-screen.
+
 - **Voice misfires:** lower background noise or switch to a smaller Vosk model.
 
 Happy racing! 🏁


### PR DESCRIPTION
### Motivation
- Make the Quick Start guide easier to scan by adding breathing room between related items.
- Reduce friction for new users by surfacing the key setup steps as a short checklist and clearer blocks.
- Improve overall readability of the guide without changing any behavior or dependencies.

### Description
- Updated `docs/guides/quickstart.md` to add a brief checklist intro and insert extra blank lines for visual separation.
- Added spacing between grouped list items in sections including `Before You Begin`, `Scan & Configure`, `Combos & Timing`, `Voice & Audio`, `Maintenance`, and `Common Fixes`.
- This is a formatting-only documentation change and does not modify application code or requirements.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ec212e8b48333871154a45d8c8ff5)