### PR TITLE
Support array telemetry in HUD overlay feedback

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -30,6 +30,7 @@ import subprocess
 import importlib
 import queue
 import numbers
+from array import array
 import tempfile
 import wave
 from typing import Dict, List, Tuple, Optional, Any, Callable
@@ -5908,7 +5909,7 @@ class iRacingControlApp:
         for key in keys:
             value = self._read_ir_value(key)
 
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, (list, tuple, array)):
                 if any(bool(v) for v in value):
                     return True
             elif isinstance(value, numbers.Real):
@@ -5925,7 +5926,7 @@ class iRacingControlApp:
         slips: List[float] = []
         for key in ["WheelSlip", "WheelSlipPct", "WheelSlipRatio", "TireSlip"]:
             value = self._read_ir_value(key)
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, (list, tuple, array)):
                 slips.extend([self._safe_float(v, 0.0) for v in value])
 
         return slips


### PR DESCRIPTION
### Motivation
- The HUD overlay never showed ABS/TC/slip hints when iRacing returned array-style telemetry values.  
- The overlay feedback logic only treated `list`/`tuple` sequences as multi-value telemetry, missing `array.array` types.  

### Description
- Import `array` from the standard library and include it in type checks.  
- Extend the `isinstance` checks in `_bool_from_keys` to accept `array` so ABS/TC boolean arrays are evaluated.  
- Extend the `isinstance` checks in `_slip_values` to accept `array` so slip ratio arrays are aggregated.  

### Testing
- No automated tests were executed for this change.  
- Manual verification is expected to be performed in an iRacing environment to confirm overlay feedback now triggers for array telemetry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ec39d9a248333bdb7ed2efe971394)