### PR TITLE
Default timing profile to BOT and reorder profiles (BOT first)

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -3501,8 +3501,24 @@ class GlobalTimingWindow(tk.Toplevel):
         profiles_frame.pack(fill="x", padx=10, pady=5)
 
         self.var_profile = tk.StringVar(
-            value=GLOBAL_TIMING.get("profile", "aggressive")
+            value=GLOBAL_TIMING.get("profile", "bot")
         )
+
+        tk.Radiobutton(
+            profiles_frame,
+            text="🤖 BOT (experimental, near-zero delay)",
+            variable=self.var_profile,
+            value="bot",
+            command=self._on_profile_change
+        ).pack(anchor="w", padx=5, pady=2)
+
+        tk.Radiobutton(
+            profiles_frame,
+            text="🤖 BOT Stable (fast, more reliable)",
+            variable=self.var_profile,
+            value="bot_safe",
+            command=self._on_profile_change
+        ).pack(anchor="w", padx=5, pady=2)
 
         tk.Radiobutton(
             profiles_frame,
@@ -3525,22 +3541,6 @@ class GlobalTimingWindow(tk.Toplevel):
             text="😎 Relaxed (well-spaced)",
             variable=self.var_profile,
             value="relaxed",
-            command=self._on_profile_change
-        ).pack(anchor="w", padx=5, pady=2)
-
-        tk.Radiobutton(
-            profiles_frame,
-            text="🤖 BOT (experimental, near-zero delay)",
-            variable=self.var_profile,
-            value="bot",
-            command=self._on_profile_change
-        ).pack(anchor="w", padx=5, pady=2)
-
-        tk.Radiobutton(
-            profiles_frame,
-            text="🤖 BOT Stable (fast, more reliable)",
-            variable=self.var_profile,
-            value="bot_safe",
             command=self._on_profile_change
         ).pack(anchor="w", padx=5, pady=2)
 


### PR DESCRIPTION
### Motivation
- Present timing profile choices in fastest-to-slowest order so users see the lowest-latency option first. 
- Make `bot` the default selection in the timing UI so the experimental near-zero delay mode is enabled by default.
- Ensure the UI change aligns with existing timing logic that treats `bot` as the ultra-low-latency profile (1ms).
- Improve discoverability of the `bot` and `bot_safe` profiles in the `Timing` configuration window.

### Description
- Changed the default value used by the timing window to `GLOBAL_TIMING.get("profile", "bot")` so the UI falls back to `bot`.
- Reordered the `tk.Radiobutton` entries in `GlobalTimingWindow` so `bot` and `bot_safe` appear at the top, followed by `aggressive`, `casual`, `relaxed`, and `custom`.
- No logic changes were made to `_compute_timing`; the `bot` profile continues to use `press_ms = 1` and `interval_ms = 1` with a `min_value` of `1`.
- Only UI ordering and default selection were modified in `FINALOK.py`.

### Testing
- No automated tests were run for this change.
- No test failures reported because no tests were executed.
- The change is limited to UI construction and does not alter timing computation logic covered by existing code paths.
- Manual validation is recommended to ensure the UI reflects the new ordering and default selection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ec5f5cb7883338d28cf6b341a3582)