### PR TITLE
Treat dcBrakeBias as float during driver controls scan

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -5539,6 +5539,9 @@ class iRacingControlApp:
                 return {"status": "unavailable"}
 
             found_vars = []
+            forced_float_vars = {
+                "dcBrakeBias",
+            }
 
             # Base candidates
             candidates = [
@@ -5592,7 +5595,7 @@ class iRacingControlApp:
                     if not isinstance(value, numbers.Real):
                         continue
 
-                    is_float = (float(value) % 1.0) != 0.0
+                    is_float = candidate in forced_float_vars or (float(value) % 1.0) != 0.0
                     found_vars.append((candidate, is_float))
 
             except Exception as e:

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -5539,6 +5539,9 @@ class iRacingControlApp:
                 return {"status": "unavailable"}
 
             found_vars = []
+            forced_float_vars = {
+                "dcBrakeBias",
+            }
 
             # Base candidates
             candidates = [
@@ -5592,7 +5595,7 @@ class iRacingControlApp:
                     if not isinstance(value, numbers.Real):
                         continue
 
-                    is_float = (float(value) % 1.0) != 0.0
+                    is_float = candidate in forced_float_vars or (float(value) % 1.0) != 0.0
                     found_vars.append((candidate, is_float))
 
             except Exception as e:


### PR DESCRIPTION
### Motivation
- The driver control scan detected numeric type by checking `(float(value) % 1.0) != 0.0`, which classifies values like `52.00` as integers and can miss subsequent fractional changes (e.g. `52.25`).
- `dcBrakeBias` should be treated as a float even when its initial value has no fractional part to avoid losing precision when the value changes.
- The change needs to be applied to both English and Portuguese app variants to keep behavior consistent.

### Description
- Added a `forced_float_vars` set containing `"dcBrakeBias"` in both `FINALOK.py` and `FINALOKPTBR.py`.
- Updated the float-detection logic to set `is_float = candidate in forced_float_vars or (float(value) % 1.0) != 0.0` so `dcBrakeBias` is always treated as a float.
- The change only affects the driver control scanning worker and preserves existing candidate discovery and sorting logic.

### Testing
- No automated tests were executed for this change.
- Manual verification is recommended in a session where `dcBrakeBias` moves from `.00` to a fractional value to confirm decimals are detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695eccbf987c8333860bd9414cfaed4a)