### PR TITLE
Treat all dc* controls as floats during scan

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -5539,9 +5539,6 @@ class iRacingControlApp:
                 return {"status": "unavailable"}
 
             found_vars = []
-            forced_float_vars = {
-                "dcBrakeBias",
-            }
 
             # Base candidates
             candidates = [
@@ -5595,8 +5592,7 @@ class iRacingControlApp:
                     if not isinstance(value, numbers.Real):
                         continue
 
-                    is_float = candidate in forced_float_vars or (float(value) % 1.0) != 0.0
-                    found_vars.append((candidate, is_float))
+                    found_vars.append((candidate, True))
 
             except Exception as e:
                 print(f"[Scan] Error reading variables: {e}")

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -5539,9 +5539,6 @@ class iRacingControlApp:
                 return {"status": "unavailable"}
 
             found_vars = []
-            forced_float_vars = {
-                "dcBrakeBias",
-            }
 
             # Base candidates
             candidates = [
@@ -5595,8 +5592,7 @@ class iRacingControlApp:
                     if not isinstance(value, numbers.Real):
                         continue
 
-                    is_float = candidate in forced_float_vars or (float(value) % 1.0) != 0.0
-                    found_vars.append((candidate, is_float))
+                    found_vars.append((candidate, True))
 
             except Exception as e:
                 print(f"[Verificação] Erro ao ler variáveis: {e}")

--- a/test_telemetry.py
+++ b/test_telemetry.py
@@ -48,8 +48,7 @@ def collect_dc_vars(ir: irsdk.IRSDK) -> List[Tuple[str, bool]]:
             continue
         if not isinstance(value, numbers.Real):
             continue
-        is_float = (float(value) % 1.0) != 0.0
-        found_vars.append((candidate, is_float))
+        found_vars.append((candidate, True))
 
     return found_vars
 


### PR DESCRIPTION
### Motivation
- Ensure driver control (`dc*`) variables are treated as floating-point values (except booleans) so UI bindings and presets do not get locked to integer mode when a value happens to be an integer at scan time.
- Apply the behavior both to the hardcoded candidate list and variables discovered from the SDK so newly detected `dc*` keys are also floats.
- Keep parity between the English and PT-BR UI variants and align the telemetry test helper script.

### Description
- Updated the scanning logic in `FINALOK.py` to mark every detected numeric `dc*` variable as float by appending `(name, True)` for each numeric candidate instead of inferring float-ness from the current value.
- Mirrored the same change in `FINALOKPTBR.py` so the PT-BR variant uses identical float handling.
- Updated `test_telemetry.py` `collect_dc_vars()` to also mark discovered numeric `dc*` variables as floats for consistent formatting/printing.
- Removed the prior per-variable float detection and the small `forced_float_vars` special-case in favor of always treating numeric `dc*` variables as floats.

### Testing
- No automated tests were run as part of this change.
- Manual runtime behavior: scanning code now returns `vars` entries with `is_float=True` for all numeric `dc*` keys (expected behavior described above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ed02152588333a1fde2bf04b1829b)