### PR TITLE
Add 'Show all connected devices' toggle to expose HIDAPI/XInput devices

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -821,6 +821,7 @@ class InputManager:
         self.active: bool = False
         self.allowed_devices: List[str] = []
         self.safe_mode: bool = False
+        self.show_all_devices: bool = os.getenv("DOMINANTCONTROL_SHOW_ALL_DEVICES", "0") == "1"
         self._input_thread: Optional[threading.Thread] = None
         self._input_watchdog = Watchdog(
             "InputManager", interval_s=2.5, timeout_s=8.0, on_trip=self._restart_input_loop
@@ -830,16 +831,38 @@ class InputManager:
 
         if HAS_PYGAME:
             try:
-                if self.preserve_game_ffb:
-                    # Prefer the legacy/direct drivers instead of HIDAPI/XInput to avoid taking over FFB
-                    os.environ.setdefault("SDL_HINT_JOYSTICK_HIDAPI", "0")
-                    os.environ.setdefault("SDL_HINT_XINPUT_ENABLED", "0")
-                    os.environ.setdefault("SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1")
+                self._apply_joystick_hints()
                 pygame.init()
                 pygame.joystick.init()
                 self._start_input_loop()
             except Exception as e:
                 print(f"[InputManager] Pygame init error: {e}")
+
+    def _apply_joystick_hints(self):
+        if not self.preserve_game_ffb or self.show_all_devices:
+            os.environ["SDL_HINT_JOYSTICK_HIDAPI"] = "1"
+            os.environ["SDL_HINT_XINPUT_ENABLED"] = "1"
+        else:
+            # Prefer the legacy/direct drivers instead of HIDAPI/XInput to avoid taking over FFB
+            os.environ["SDL_HINT_JOYSTICK_HIDAPI"] = "0"
+            os.environ["SDL_HINT_XINPUT_ENABLED"] = "0"
+        os.environ.setdefault("SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1")
+
+    def set_show_all_devices(self, enabled: bool):
+        """Toggle discovery of all USB devices (including HIDAPI/XInput)."""
+        self.show_all_devices = enabled
+        if self.safe_mode or not HAS_PYGAME:
+            return
+        try:
+            pygame.quit()
+        except Exception:
+            pass
+        self._apply_joystick_hints()
+        try:
+            pygame.init()
+            pygame.joystick.init()
+        except Exception as exc:
+            print(f"[InputManager] Error reinitializing pygame: {exc}")
 
     def set_safe_mode(self, enabled: bool):
         """
@@ -1684,6 +1707,7 @@ class DeviceSelector(tk.Toplevel):
         self.title("Manage USB Devices")
         self.geometry("450x400")
         self.callback = callback
+        self.show_all_var = tk.BooleanVar(value=input_manager.show_all_devices)
 
         tk.Label(
             self,
@@ -1698,28 +1722,25 @@ class DeviceSelector(tk.Toplevel):
             fg="gray"
         ).pack()
 
+        tk.Checkbutton(
+            self,
+            text="Show all connected devices (includes HIDAPI/XInput)",
+            variable=self.show_all_var,
+            command=self._toggle_show_all
+        ).pack(pady=(4, 0))
+
+        tk.Button(
+            self,
+            text="Refresh device list",
+            command=self._refresh_devices
+        ).pack(pady=(6, 0))
+
         self.frame_list = tk.Frame(self)
         self.frame_list.pack(fill="both", expand=True, padx=10, pady=10)
 
         self.check_vars: Dict[str, tk.BooleanVar] = {}
-        all_devices = input_manager.get_all_devices()
-
-        for idx, name in all_devices:
-            var = tk.BooleanVar()
-            if current_allowed:
-                var.set(name in current_allowed)
-            else:
-                # First run defaults to nothing selected
-                var.set(False)
-
-            chk = tk.Checkbutton(
-                self.frame_list, 
-                text=name, 
-                variable=var, 
-                anchor="w"
-            )
-            chk.pack(fill="x")
-            self.check_vars[name] = var
+        self._current_allowed = current_allowed
+        self._refresh_devices()
 
         tk.Button(
             self,
@@ -1728,6 +1749,33 @@ class DeviceSelector(tk.Toplevel):
             bg="#90ee90",
             height=2
         ).pack(fill="x", padx=10, pady=10)
+
+    def _toggle_show_all(self):
+        input_manager.set_show_all_devices(self.show_all_var.get())
+        self._refresh_devices()
+
+    def _refresh_devices(self):
+        for child in self.frame_list.winfo_children():
+            child.destroy()
+        self.check_vars.clear()
+
+        all_devices = input_manager.get_all_devices()
+        for _, name in all_devices:
+            var = tk.BooleanVar()
+            if self._current_allowed:
+                var.set(name in self._current_allowed)
+            else:
+                # First run defaults to nothing selected
+                var.set(False)
+
+            chk = tk.Checkbutton(
+                self.frame_list,
+                text=name,
+                variable=var,
+                anchor="w"
+            )
+            chk.pack(fill="x")
+            self.check_vars[name] = var
 
     def save(self):
         """Save device selection and close dialog."""
@@ -6169,6 +6217,7 @@ class iRacingControlApp:
             "pending_scan_on_start": self.pending_scan_on_start,
             "rescan_restart_pair": list(self._rescan_restart_pair),
             "allowed_devices": input_manager.allowed_devices,
+            "show_all_devices": input_manager.show_all_devices,
             "saved_presets": self.saved_presets,
             "car_overlay_config": self.car_overlay_config,
             "car_overlay_feedback": self.car_overlay_feedback,
@@ -6234,6 +6283,7 @@ class iRacingControlApp:
             self._rescan_restart_pair = (pair[0], pair[1])
 
         input_manager.allowed_devices = data.get("allowed_devices", [])
+        input_manager.set_show_all_devices(data.get("show_all_devices", False))
 
         self.saved_presets = data.get("saved_presets", {})
         self.car_overlay_config = data.get("car_overlay_config", {})

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -821,6 +821,7 @@ class InputManager:
         self.active: bool = False
         self.allowed_devices: List[str] = []
         self.safe_mode: bool = False
+        self.show_all_devices: bool = os.getenv("DOMINANTCONTROL_SHOW_ALL_DEVICES", "0") == "1"
         self._input_thread: Optional[threading.Thread] = None
         self._input_watchdog = Watchdog(
             "InputManager", interval_s=2.5, timeout_s=8.0, on_trip=self._restart_input_loop
@@ -830,16 +831,38 @@ class InputManager:
 
         if HAS_PYGAME:
             try:
-                if self.preserve_game_ffb:
-                    # Prefer the legacy/direct drivers instead of HIDAPI/XInput to avoid taking over FFB
-                    os.environ.setdefault("SDL_HINT_JOYSTICK_HIDAPI", "0")
-                    os.environ.setdefault("SDL_HINT_XINPUT_ENABLED", "0")
-                    os.environ.setdefault("SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1")
+                self._apply_joystick_hints()
                 pygame.init()
                 pygame.joystick.init()
                 self._start_input_loop()
             except Exception as e:
                 print(f"[InputManager] Erro ao iniciar o pygame: {e}")
+
+    def _apply_joystick_hints(self):
+        if not self.preserve_game_ffb or self.show_all_devices:
+            os.environ["SDL_HINT_JOYSTICK_HIDAPI"] = "1"
+            os.environ["SDL_HINT_XINPUT_ENABLED"] = "1"
+        else:
+            # Prefer the legacy/direct drivers instead of HIDAPI/XInput to avoid taking over FFB
+            os.environ["SDL_HINT_JOYSTICK_HIDAPI"] = "0"
+            os.environ["SDL_HINT_XINPUT_ENABLED"] = "0"
+        os.environ.setdefault("SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1")
+
+    def set_show_all_devices(self, enabled: bool):
+        """Toggle discovery of all USB devices (including HIDAPI/XInput)."""
+        self.show_all_devices = enabled
+        if self.safe_mode or not HAS_PYGAME:
+            return
+        try:
+            pygame.quit()
+        except Exception:
+            pass
+        self._apply_joystick_hints()
+        try:
+            pygame.init()
+            pygame.joystick.init()
+        except Exception as exc:
+            print(f"[InputManager] Erro ao reinicializar pygame: {exc}")
 
     def set_safe_mode(self, enabled: bool):
         """
@@ -1684,6 +1707,7 @@ class DeviceSelector(tk.Toplevel):
         self.title("Gerenciar dispositivos USB")
         self.geometry("450x400")
         self.callback = callback
+        self.show_all_var = tk.BooleanVar(value=input_manager.show_all_devices)
 
         tk.Label(
             self,
@@ -1698,28 +1722,25 @@ class DeviceSelector(tk.Toplevel):
             fg="gray"
         ).pack()
 
+        tk.Checkbutton(
+            self,
+            text="Mostrar todos os dispositivos conectados (inclui HIDAPI/XInput)",
+            variable=self.show_all_var,
+            command=self._toggle_show_all
+        ).pack(pady=(4, 0))
+
+        tk.Button(
+            self,
+            text="Atualizar lista de dispositivos",
+            command=self._refresh_devices
+        ).pack(pady=(6, 0))
+
         self.frame_list = tk.Frame(self)
         self.frame_list.pack(fill="both", expand=True, padx=10, pady=10)
 
         self.check_vars: Dict[str, tk.BooleanVar] = {}
-        all_devices = input_manager.get_all_devices()
-
-        for idx, name in all_devices:
-            var = tk.BooleanVar()
-            if current_allowed:
-                var.set(name in current_allowed)
-            else:
-                # First run defaults to nothing selected
-                var.set(False)
-
-            chk = tk.Checkbutton(
-                self.frame_list, 
-                text=name, 
-                variable=var, 
-                anchor="w"
-            )
-            chk.pack(fill="x")
-            self.check_vars[name] = var
+        self._current_allowed = current_allowed
+        self._refresh_devices()
 
         tk.Button(
             self,
@@ -1728,6 +1749,33 @@ class DeviceSelector(tk.Toplevel):
             bg="#90ee90",
             height=2
         ).pack(fill="x", padx=10, pady=10)
+
+    def _toggle_show_all(self):
+        input_manager.set_show_all_devices(self.show_all_var.get())
+        self._refresh_devices()
+
+    def _refresh_devices(self):
+        for child in self.frame_list.winfo_children():
+            child.destroy()
+        self.check_vars.clear()
+
+        all_devices = input_manager.get_all_devices()
+        for _, name in all_devices:
+            var = tk.BooleanVar()
+            if self._current_allowed:
+                var.set(name in self._current_allowed)
+            else:
+                # First run defaults to nothing selected
+                var.set(False)
+
+            chk = tk.Checkbutton(
+                self.frame_list,
+                text=name,
+                variable=var,
+                anchor="w"
+            )
+            chk.pack(fill="x")
+            self.check_vars[name] = var
 
     def save(self):
         """Save device selection and close dialog."""
@@ -6169,6 +6217,7 @@ class iRacingControlApp:
             "pending_scan_on_start": self.pending_scan_on_start,
             "rescan_restart_pair": list(self._rescan_restart_pair),
             "allowed_devices": input_manager.allowed_devices,
+            "show_all_devices": input_manager.show_all_devices,
             "saved_presets": self.saved_presets,
             "car_overlay_config": self.car_overlay_config,
             "car_overlay_feedback": self.car_overlay_feedback,
@@ -6234,6 +6283,7 @@ class iRacingControlApp:
             self._rescan_restart_pair = (pair[0], pair[1])
 
         input_manager.allowed_devices = data.get("allowed_devices", [])
+        input_manager.set_show_all_devices(data.get("show_all_devices", False))
 
         self.saved_presets = data.get("saved_presets", {})
         self.car_overlay_config = data.get("car_overlay_config", {})


### PR DESCRIPTION
### Motivation

- Some USB/HID/XInput controllers (e.g. button boxes) were not listed because the code prefers legacy drivers to avoid FFB takeover. 
- Allow users to opt-in to seeing everything attached to the PC (no filtering) so purely-button devices can be discovered and used. 
- Provide a UI control so the user can toggle discovery without editing environment variables. 

### Description

- Added a `show_all_devices` flag (env var `DOMINANTCONTROL_SHOW_ALL_DEVICES`) and wired it into the `InputManager` in `FINALOK.py` and `FINALOKPTBR.py`.
- Introduced `_apply_joystick_hints()` and `set_show_all_devices()` to switch SDL hints (`SDL_HINT_JOYSTICK_HIDAPI`, `SDL_HINT_XINPUT_ENABLED`) and reinitialize `pygame` so HIDAPI/XInput devices can be discovered.
- Updated the device manager UI (`DeviceSelector`) to include a `Show all connected devices` checkbox, a `Refresh device list` button, and a dynamic `_refresh_devices()` flow so users can toggle and refresh visible devices immediately.
- Persisted the new `show_all_devices` setting to config (`save_config`/`load_config`) for both English and PT-BR variants (`FINALOK.py`, `FINALOKPTBR.py`).

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695ee1536e54832a8339845c4893b4aa)