### PR TITLE
Connect all joystick devices and list all devices in selector

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -900,7 +900,7 @@ class InputManager:
 
     def connect_allowed_devices(self, allowed_names: List[str]):
         """
-        Connect only devices in the allowed list.
+        Connect all available devices.
         
         Args:
             allowed_names: List of device names to allow
@@ -917,19 +917,14 @@ class InputManager:
             if not pygame.joystick.get_init():
                 pygame.joystick.init()
 
-            if not self.allowed_devices:
-                # No devices have been approved yet
-                return
-
             for i in range(pygame.joystick.get_count()):
                 j = pygame.joystick.Joystick(i)
-                if j.get_name() in self.allowed_devices:
-                    try:
-                        j.init()
-                        self.joysticks.append(j)
-                        print(f"[InputManager] Connected: {j.get_name()}")
-                    except Exception:
-                        pass
+                try:
+                    j.init()
+                    self.joysticks.append(j)
+                    print(f"[InputManager] Connected: {j.get_name()}")
+                except Exception:
+                    pass
         except Exception:
             pass
 
@@ -1706,11 +1701,8 @@ class DeviceSelector(tk.Toplevel):
 
         for idx, name in all_devices:
             var = tk.BooleanVar()
-            if current_allowed:
-                var.set(name in current_allowed)
-            else:
-                # First run defaults to nothing selected
-                var.set(False)
+            # Default to nothing selected
+            var.set(False)
 
             chk = tk.Checkbutton(
                 self.frame_list, 


### PR DESCRIPTION
### Motivation
- Simplify device onboarding by initializing and connecting every detected joystick instead of restricting connections to a prior allowlist.
- Ensure the device UI shows every detected device so users can explicitly permit usage via the dialog rather than hiding unapproved devices.
- Preserve the existing safety behavior so joystick handling remains disabled when `safe_mode` (keyboard-only mode) is active.
- Reduce friction during first-run device discovery while keeping an explicit allowlist persisted for later use.

### Description
- Updated `connect_allowed_devices` to iterate over `pygame.joystick.get_count()` and initialize and append every joystick to `self.joysticks` instead of filtering by `allowed_names`, while still storing `self.allowed_devices`.
- Removed the early-return when no `allowed_devices` are present so devices are connected regardless of prior approvals (but only when not in `safe_mode` and `HAS_PYGAME`).
- Changed the device selection UI (`DeviceSelector`) to list all devices from `input_manager.get_all_devices()` and default all checkboxes to unchecked rather than pre-selecting based on `current_allowed`.
- Left the `safe_mode` / `HAS_PYGAME` guards intact so the new logic only runs when keyboard-only mode is off.

### Testing
- No automated tests were executed for this change.
- Changes were validated by static inspection of the modified `FINALOK.py` file and commit recorded locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695eec054000832a91fa14c6924902b0)