### PR TITLE
Align macro and combo column widths and padding (EN + PT-BR)

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -2820,32 +2820,42 @@ class ControlTab(tk.Frame):
             justify="left"
         ).pack(anchor="w", padx=2, pady=(0, 5))
 
+        self.type_width = 8
+        self.macro_width = 12
+        self.keybind_width = 14
+        self.voice_width = 22
+        self.column_pad = 4
+
         header = tk.Frame(presets_frame)
-        header.pack(fill="x", padx=2, pady=(0, 2))
+        header.pack(fill="x", padx=self.column_pad, pady=(0, 2))
         tk.Label(
-            header, text="Type", width=6, anchor="w", font=("Arial", 8, "bold")
+            header,
+            text="Type",
+            width=self.type_width,
+            anchor="w",
+            font=("Arial", 8, "bold")
         ).pack(side="left")
         tk.Label(
             header,
             text="Macro value",
-            width=8,
+            width=self.macro_width,
             anchor="w",
             font=("Arial", 8, "bold")
-        ).pack(side="left", padx=5)
+        ).pack(side="left", padx=self.column_pad)
         tk.Label(
             header,
             text="Keybinding",
-            width=12,
+            width=self.keybind_width,
             anchor="w",
             font=("Arial", 8, "bold")
-        ).pack(side="left", padx=5)
+        ).pack(side="left", padx=self.column_pad)
         tk.Label(
             header,
             text="Voice trigger phrase",
-            width=18,
+            width=self.voice_width,
             anchor="w",
             font=("Arial", 8, "bold")
-        ).pack(side="left", padx=5)
+        ).pack(side="left", padx=self.column_pad)
 
         self.presets_container = tk.Frame(presets_frame)
         self.presets_container.pack(fill="both", expand=True)
@@ -3008,23 +3018,23 @@ class ControlTab(tk.Frame):
         tk.Label(
             frame,
             text=label_text,
-            width=6,
+            width=self.type_width,
             anchor="w",
             fg="red" if is_reset else "black"
         ).pack(side="left")
 
-        value_entry = ttk.Entry(frame, width=8)
-        value_entry.pack(side="left", padx=5)
+        value_entry = ttk.Entry(frame, width=self.macro_width)
+        value_entry.pack(side="left", padx=self.column_pad)
         self._bind_autosave_entry(value_entry)
 
         if self.app.app_state != "CONFIG":
             value_entry.config(state="readonly")
 
-        bind_button = tk.Button(frame, text="Set Bind", width=12)
-        bind_button.pack(side="left", padx=5)
+        bind_button = tk.Button(frame, text="Set Bind", width=self.keybind_width)
+        bind_button.pack(side="left", padx=self.column_pad)
 
-        voice_entry = ttk.Entry(frame, width=18)
-        voice_entry.pack(side="left", padx=5)
+        voice_entry = ttk.Entry(frame, width=self.voice_width)
+        voice_entry.pack(side="left", padx=self.column_pad)
         voice_entry.insert(0, "")
         self._bind_autosave_entry(voice_entry)
         if self.app.app_state != "CONFIG":
@@ -3191,18 +3201,15 @@ class ComboTab(tk.Frame):
         self.controllers = controllers_dict
         self.var_names = list(self.controllers.keys())
         self.preset_rows: List[Dict[str, Any]] = []
-        if self.var_names:
-            self.column_width = max(
-                8,
-                min(
-                    18,
-                    max(
-                        len(name.replace("dc", "")) for name in self.var_names
-                    ) + 2
-                )
-            )
+        self.display_names = [name.replace("dc", "") for name in self.var_names]
+        if self.display_names:
+            max_display_len = max(len(name) for name in self.display_names)
+            self.column_width = max(10, min(22, max_display_len + 2))
         else:
-            self.column_width = 8
+            self.column_width = 10
+        self.trigger_width = 15
+        self.voice_width = 22
+        self.column_pad = 3
 
         scroll_frame = ScrollableFrame(self)
         scroll_frame.pack(fill="both", expand=True)
@@ -3222,27 +3229,27 @@ class ComboTab(tk.Frame):
         tk.Label(
             header, 
             text="Trigger", 
-            width=15, 
+            width=self.trigger_width,
             anchor="w", 
             font=("Arial", 9, "bold")
-        ).pack(side="left", padx=2)
+        ).pack(side="left", padx=self.column_pad)
 
-        for var_name in self.var_names:
+        for var_name, display_name in zip(self.var_names, self.display_names):
             tk.Label(
                 header,
-                text=var_name.replace("dc", ""),
+                text=display_name,
                 width=self.column_width,
                 anchor="w",
                 font=("Arial", 8)
-            ).pack(side="left", padx=2)
+            ).pack(side="left", padx=self.column_pad)
 
         tk.Label(
             header,
             text="Voice trigger phrase",
-            width=18,
+            width=self.voice_width,
             anchor="w",
             font=("Arial", 8, "bold")
-        ).pack(side="left", padx=4)
+        ).pack(side="left", padx=self.column_pad)
 
         tk.Label(
             body,
@@ -3350,10 +3357,10 @@ class ComboTab(tk.Frame):
         bind_button = tk.Button(
             frame,
             text="RESET" if is_reset else "Set Bind",
-            width=15,
+            width=self.trigger_width,
             fg="red" if is_reset else "black"
         )
-        bind_button.pack(side="left", padx=2)
+        bind_button.pack(side="left", padx=self.column_pad)
 
         row_data = {
             "frame": frame,
@@ -3368,7 +3375,7 @@ class ComboTab(tk.Frame):
         # Create entry for each variable
         for var_name in self.var_names:
             entry = ttk.Entry(frame, width=self.column_width)
-            entry.pack(side="left", padx=2)
+            entry.pack(side="left", padx=self.column_pad)
             if self.app.app_state != "CONFIG":
                 entry.config(state="readonly")
             row_data["entries"][var_name] = entry
@@ -3392,8 +3399,8 @@ class ComboTab(tk.Frame):
                 )
                 bind_button.config(text=row_data["bind"], bg=bg_color)
 
-        voice_entry = ttk.Entry(frame, width=18)
-        voice_entry.pack(side="left", padx=4)
+        voice_entry = ttk.Entry(frame, width=self.voice_width)
+        voice_entry.pack(side="left", padx=self.column_pad)
         if existing and existing.get("voice_phrase"):
             voice_entry.insert(0, existing.get("voice_phrase", ""))
         if self.app.app_state != "CONFIG":

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -2820,32 +2820,42 @@ class ControlTab(tk.Frame):
             justify="left"
         ).pack(anchor="w", padx=2, pady=(0, 5))
 
+        self.type_width = 8
+        self.macro_width = 12
+        self.keybind_width = 14
+        self.voice_width = 22
+        self.column_pad = 4
+
         header = tk.Frame(presets_frame)
-        header.pack(fill="x", padx=2, pady=(0, 2))
+        header.pack(fill="x", padx=self.column_pad, pady=(0, 2))
         tk.Label(
-            header, text="Tipo", width=6, anchor="w", font=("Arial", 8, "bold")
+            header,
+            text="Tipo",
+            width=self.type_width,
+            anchor="w",
+            font=("Arial", 8, "bold")
         ).pack(side="left")
         tk.Label(
             header,
             text="Valor da macro",
-            width=8,
+            width=self.macro_width,
             anchor="w",
             font=("Arial", 8, "bold")
-        ).pack(side="left", padx=5)
+        ).pack(side="left", padx=self.column_pad)
         tk.Label(
             header,
             text="Atalho",
-            width=12,
+            width=self.keybind_width,
             anchor="w",
             font=("Arial", 8, "bold")
-        ).pack(side="left", padx=5)
+        ).pack(side="left", padx=self.column_pad)
         tk.Label(
             header,
             text="Frase de gatilho de voz",
-            width=18,
+            width=self.voice_width,
             anchor="w",
             font=("Arial", 8, "bold")
-        ).pack(side="left", padx=5)
+        ).pack(side="left", padx=self.column_pad)
 
         self.presets_container = tk.Frame(presets_frame)
         self.presets_container.pack(fill="both", expand=True)
@@ -3008,23 +3018,27 @@ class ControlTab(tk.Frame):
         tk.Label(
             frame,
             text=label_text,
-            width=6,
+            width=self.type_width,
             anchor="w",
             fg="red" if is_reset else "black"
         ).pack(side="left")
 
-        value_entry = ttk.Entry(frame, width=8)
-        value_entry.pack(side="left", padx=5)
+        value_entry = ttk.Entry(frame, width=self.macro_width)
+        value_entry.pack(side="left", padx=self.column_pad)
         self._bind_autosave_entry(value_entry)
 
         if self.app.app_state != "CONFIG":
             value_entry.config(state="readonly")
 
-        bind_button = tk.Button(frame, text="Definir atalho", width=12)
-        bind_button.pack(side="left", padx=5)
+        bind_button = tk.Button(
+            frame,
+            text="Definir atalho",
+            width=self.keybind_width
+        )
+        bind_button.pack(side="left", padx=self.column_pad)
 
-        voice_entry = ttk.Entry(frame, width=18)
-        voice_entry.pack(side="left", padx=5)
+        voice_entry = ttk.Entry(frame, width=self.voice_width)
+        voice_entry.pack(side="left", padx=self.column_pad)
         voice_entry.insert(0, "")
         self._bind_autosave_entry(voice_entry)
         if self.app.app_state != "CONFIG":
@@ -3191,18 +3205,15 @@ class ComboTab(tk.Frame):
         self.controllers = controllers_dict
         self.var_names = list(self.controllers.keys())
         self.preset_rows: List[Dict[str, Any]] = []
-        if self.var_names:
-            self.column_width = max(
-                8,
-                min(
-                    18,
-                    max(
-                        len(name.replace("dc", "")) for name in self.var_names
-                    ) + 2
-                )
-            )
+        self.display_names = [name.replace("dc", "") for name in self.var_names]
+        if self.display_names:
+            max_display_len = max(len(name) for name in self.display_names)
+            self.column_width = max(10, min(22, max_display_len + 2))
         else:
-            self.column_width = 8
+            self.column_width = 10
+        self.trigger_width = 15
+        self.voice_width = 22
+        self.column_pad = 3
 
         scroll_frame = ScrollableFrame(self)
         scroll_frame.pack(fill="both", expand=True)
@@ -3222,27 +3233,27 @@ class ComboTab(tk.Frame):
         tk.Label(
             header, 
             text="Gatilho", 
-            width=15, 
+            width=self.trigger_width,
             anchor="w", 
             font=("Arial", 9, "bold")
-        ).pack(side="left", padx=2)
+        ).pack(side="left", padx=self.column_pad)
 
-        for var_name in self.var_names:
+        for var_name, display_name in zip(self.var_names, self.display_names):
             tk.Label(
                 header,
-                text=var_name.replace("dc", ""),
+                text=display_name,
                 width=self.column_width,
                 anchor="w",
                 font=("Arial", 8)
-            ).pack(side="left", padx=2)
+            ).pack(side="left", padx=self.column_pad)
 
         tk.Label(
             header,
             text="Frase de gatilho de voz",
-            width=18,
+            width=self.voice_width,
             anchor="w",
             font=("Arial", 8, "bold")
-        ).pack(side="left", padx=4)
+        ).pack(side="left", padx=self.column_pad)
 
         tk.Label(
             body,
@@ -3350,10 +3361,10 @@ class ComboTab(tk.Frame):
         bind_button = tk.Button(
             frame,
             text="RESETAR" if is_reset else "Definir atalho",
-            width=15,
+            width=self.trigger_width,
             fg="red" if is_reset else "black"
         )
-        bind_button.pack(side="left", padx=2)
+        bind_button.pack(side="left", padx=self.column_pad)
 
         row_data = {
             "frame": frame,
@@ -3368,7 +3379,7 @@ class ComboTab(tk.Frame):
         # Create entry for each variable
         for var_name in self.var_names:
             entry = ttk.Entry(frame, width=self.column_width)
-            entry.pack(side="left", padx=2)
+            entry.pack(side="left", padx=self.column_pad)
             if self.app.app_state != "CONFIG":
                 entry.config(state="readonly")
             row_data["entries"][var_name] = entry
@@ -3392,8 +3403,8 @@ class ComboTab(tk.Frame):
                 )
                 bind_button.config(text=row_data["bind"], bg=bg_color)
 
-        voice_entry = ttk.Entry(frame, width=18)
-        voice_entry.pack(side="left", padx=4)
+        voice_entry = ttk.Entry(frame, width=self.voice_width)
+        voice_entry.pack(side="left", padx=self.column_pad)
         if existing and existing.get("voice_phrase"):
             voice_entry.insert(0, existing.get("voice_phrase", ""))
         if self.app.app_state != "CONFIG":


### PR DESCRIPTION
### Motivation
- Improve alignment between column headers and entry fields in the Presets/Macros UI so long names aren't cut off. 
- Ensure combo rows remain visually aligned when many `dc...` variables are present by sizing columns based on display names. 
- Apply the same layout fixes to the Portuguese UI variant to keep both language builds consistent. 

### Description
- Updated preset header and row layout in `FINALOK.py` and `FINALOKPTBR.py` by introducing `type_width`, `macro_width`, `keybind_width`, `voice_width` and `column_pad` and using them for label/entry widths and padding. 
- Reworked `ComboTab` sizing to compute `display_names`, derive `column_width` from the longest display name, and added `trigger_width`, `voice_width` and `column_pad` to standardize spacing. 
- Replaced hard-coded numeric widths/padding in `add_preset_row` / `add_dynamic_row` with the new instance attributes so headers and inputs line up. 

### Testing
- No automated tests were executed because this is a UI layout change only. 
- Visual/manual inspection recommended after running the app to verify header/entry alignment and behavior with long variable names.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695f0ca54a24832a814b23b67cfa0ba5)