### PR TITLE
Guard UI status updates after tab destruction

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -2869,8 +2869,18 @@ class ControlTab(tk.Frame):
 
     def update_status_label(self, text: str, color: str):
         """Update status label."""
-        if self.app:
-            self.app.ui(self.lbl_status.config, text=text, fg=color)
+        if not self.app:
+            return
+
+        def _apply():
+            try:
+                if not self.lbl_status.winfo_exists():
+                    return
+                self.lbl_status.config(text=text, fg=color)
+            except Exception:
+                pass
+
+        self.app.ui(_apply)
 
     def _bind_autosave_entry(self, entry: tk.Entry) -> None:
         """Attach auto-save handlers to entries."""


### PR DESCRIPTION
### Motivation
- Prevent Tkinter "invalid command name" errors when a background task enqueues UI updates for widgets that have been destroyed.
- Reduce noisy `[UI] Handler error` messages caused by scheduling `lbl_status` updates after its tab is closed.

### Description
- Update `ControlTab.update_status_label` to return immediately if `self.app` is not present.
- Wrap the actual label update in an inner `_apply` callback that checks `self.lbl_status.winfo_exists()` before calling `self.lbl_status.config`.
- Run the update inside a try/except and schedule it via `self.app.ui` to ensure the change runs on the UI thread and any exceptions are swallowed.

### Testing
- No automated tests were executed for this change.
- The change is limited to guarding UI updates and does not alter non-UI logic or public APIs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696073750fb0832ab08e5d3050782652)