### PR TITLE
Fix speech_recognition import detection

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -174,11 +174,10 @@ except ImportError:
     HAS_PYAUDIO = False
     print("Warning: 'pyaudio' not installed. Audio device selection limited.")
 
-_speech_spec = importlib.util.find_spec("speech_recognition")
-if _speech_spec is not None:
+try:
     import speech_recognition as sr
     HAS_SPEECH = True
-else:
+except ImportError:
     sr = None
     HAS_SPEECH = False
     print("Warning: 'speech_recognition' not installed. Voice triggers disabled.")


### PR DESCRIPTION
### Motivation
- Some environments have a shadowed or stripped `importlib` lacking `util`, causing `AttributeError` when calling `importlib.util.find_spec("speech_recognition")`.
- The goal is to make optional `speech_recognition` detection robust across platforms and packaging scenarios.

### Description
- Replaced use of `importlib.util.find_spec("speech_recognition")` with a direct `try/except` import of `speech_recognition` in `FINALOK.py`.
- Preserve the previous optional-dependency behavior by setting `sr = None` and `HAS_SPEECH = False` on `ImportError` and keeping the same warning message.
- No behavioral changes to other optional imports or the `vosk` preparation logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960ab7a84f0832ab3acedcdcc276926)