### PR TITLE
Persist overlay visibility across sessions

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -5901,6 +5901,7 @@ class iRacingControlApp:
         else:
             self.overlay.deiconify()
             self.overlay_visible = True
+        self.schedule_save()
 
     def notify_overlay_status(self, text: str, color: str):
         """Update overlay status text temporarily."""
@@ -6192,6 +6193,7 @@ class iRacingControlApp:
         data = {
             "global_timing": GLOBAL_TIMING,
             "hud_style": self.overlay.style_cfg,
+            "overlay_visible": self.overlay_visible,
             "show_overlay_feedback": self.show_overlay_feedback.get(),
             "use_keyboard_only": self.use_keyboard_only.get(),
             "use_tts": self.use_tts.get(),
@@ -6251,6 +6253,7 @@ class iRacingControlApp:
             self.overlay.style_cfg.update(style)
             self.overlay.apply_style(self.overlay.style_cfg)
 
+        self.overlay_visible = data.get("overlay_visible", True)
         self.show_overlay_feedback.set(data.get("show_overlay_feedback", True))
 
         self.use_keyboard_only.set(data.get("use_keyboard_only", False))

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -5892,6 +5892,7 @@ class iRacingControlApp:
         else:
             self.overlay.deiconify()
             self.overlay_visible = True
+        self.schedule_save()
 
     def notify_overlay_status(self, text: str, color: str):
         """Update overlay status text temporarily."""
@@ -6183,6 +6184,7 @@ class iRacingControlApp:
         data = {
             "global_timing": GLOBAL_TIMING,
             "hud_style": self.overlay.style_cfg,
+            "overlay_visible": self.overlay_visible,
             "show_overlay_feedback": self.show_overlay_feedback.get(),
             "use_keyboard_only": self.use_keyboard_only.get(),
             "use_tts": self.use_tts.get(),
@@ -6242,6 +6244,7 @@ class iRacingControlApp:
             self.overlay.style_cfg.update(style)
             self.overlay.apply_style(self.overlay.style_cfg)
 
+        self.overlay_visible = data.get("overlay_visible", True)
         self.show_overlay_feedback.set(data.get("show_overlay_feedback", True))
 
         self.use_keyboard_only.set(data.get("use_keyboard_only", False))


### PR DESCRIPTION
### Motivation

- Ensure a user choice to hide the HUD overlay is remembered after restarting the application so it does not reappear unexpectedly.
- Keep per-language variants synchronized so both English and PT-BR builds behave the same for overlay state.

### Description

- Save the overlay visibility flag as `overlay_visible` in the configuration by updating `save_config` to include `overlay_visible`.
- Restore the saved visibility in `load_config` by assigning `self.overlay_visible = data.get("overlay_visible", True)`.
- Persist changes immediately when the user toggles the HUD by calling `self.schedule_save()` from `toggle_overlay`.
- Applied the same changes to both `FINALOK.py` and `FINALOKPTBR.py` so both language variants mirror the behavior.

### Testing

- No automated tests were executed for this change.
- Code was saved and committed locally after the modifications to the two files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960c2b70688832a938de0590a2ef0cd)