### PR TITLE
Adjust overlay feedback for cars without ABS/TC

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -6013,7 +6013,13 @@ class iRacingControlApp:
         throttle = self._safe_float(self._read_ir_value("Throttle"), 0.0)
         brake = self._safe_float(self._read_ir_value("Brake"), 0.0)
 
-        abs_active = self._bool_from_keys([
+        has_abs = "dcABS" in self.controllers
+        has_tc = any(
+            key in self.controllers
+            for key in ("dcTractionControl", "dcTractionControl2")
+        )
+
+        abs_active = has_abs and self._bool_from_keys([
             "BrakeABSactive",
             "BrakeABSActive",
             "BrakeABSActiveLF",
@@ -6021,7 +6027,7 @@ class iRacingControlApp:
             "BrakeABSActiveLR",
             "BrakeABSActiveRR",
         ])
-        tc_active = self._bool_from_keys([
+        tc_active = has_tc and self._bool_from_keys([
             "TractionControlActive",
             "TractionControlEngaged",
             "TCActive",
@@ -6072,8 +6078,13 @@ class iRacingControlApp:
             state["tc_active"] = 0.0
 
         if state["spin_active"] >= cfg["wheelspin_hold_s"]:
+            wheelspin_message = (
+                "Wheelspin detected: raise TC or modulate the throttle."
+                if has_tc
+                else "Wheelspin detected: modulate the throttle."
+            )
             self._push_overlay_alert(
-                "Wheelspin detected: raise TC or modulate the throttle.",
+                wheelspin_message,
                 "orange",
                 cfg,
                 now
@@ -6081,8 +6092,13 @@ class iRacingControlApp:
             state["spin_active"] = 0.0
 
         if state["lock_active"] >= cfg["lockup_hold_s"]:
+            lockup_message = (
+                "Lock-up detected: increase ABS or ease pedal pressure."
+                if has_abs
+                else "Lock-up detected: ease pedal pressure."
+            )
             self._push_overlay_alert(
-                "Lock-up detected: increase ABS or ease pedal pressure.",
+                lockup_message,
                 "orange",
                 cfg,
                 now

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -6004,7 +6004,13 @@ class iRacingControlApp:
         throttle = self._safe_float(self._read_ir_value("Throttle"), 0.0)
         brake = self._safe_float(self._read_ir_value("Brake"), 0.0)
 
-        abs_active = self._bool_from_keys([
+        has_abs = "dcABS" in self.controllers
+        has_tc = any(
+            key in self.controllers
+            for key in ("dcTractionControl", "dcTractionControl2")
+        )
+
+        abs_active = has_abs and self._bool_from_keys([
             "BrakeABSactive",
             "BrakeABSActive",
             "BrakeABSActiveLF",
@@ -6012,7 +6018,7 @@ class iRacingControlApp:
             "BrakeABSActiveLR",
             "BrakeABSActiveRR",
         ])
-        tc_active = self._bool_from_keys([
+        tc_active = has_tc and self._bool_from_keys([
             "TractionControlActive",
             "TractionControlEngaged",
             "TCActive",
@@ -6063,8 +6069,13 @@ class iRacingControlApp:
             state["tc_active"] = 0.0
 
         if state["spin_active"] >= cfg["wheelspin_hold_s"]:
+            wheelspin_message = (
+                "Patinagem detectada: aumente o TC ou module o acelerador."
+                if has_tc
+                else "Patinagem detectada: module o acelerador."
+            )
             self._push_overlay_alert(
-                "Patinagem detectada: aumente o TC ou module o acelerador.",
+                wheelspin_message,
                 "orange",
                 cfg,
                 now
@@ -6072,8 +6083,13 @@ class iRacingControlApp:
             state["spin_active"] = 0.0
 
         if state["lock_active"] >= cfg["lockup_hold_s"]:
+            lockup_message = (
+                "Travamento detectado: aumente o ABS ou alivie a pressão no pedal."
+                if has_abs
+                else "Travamento detectado: alivie a pressão no pedal."
+            )
             self._push_overlay_alert(
-                "Travamento detectado: aumente o ABS ou alivie a pressão no pedal.",
+                lockup_message,
                 "orange",
                 cfg,
                 now


### PR DESCRIPTION
### Motivation
- The HUD overlay can suggest actions referencing ABS/TC when the car has no such driver controls, leading to misleading tips.
- Make overlay feedback context-aware so messages only reference systems actually present for the current car.

### Description
- Gate ABS/TC detection in `_update_overlay_feedback` by checking for `dcABS` and `dcTractionControl`/`dcTractionControl2` in `self.controllers` before interpreting related telemetry.  
- Only mark `abs_active`/`tc_active` true when the corresponding driver control exists to avoid false alerts.  
- Tailor wheelspin and lock-up alert text to avoid telling the driver to change ABS/TC when those controls are not available.  
- Apply the same changes to the Portuguese variant in `FINALOKPTBR.py` to keep messages consistent.

### Testing
- No automated tests were run on these changes.
- Code changes were committed and staged (no CI execution in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69612933eae0832aa60b7c66f6fe270c)