### PR TITLE
Add startup focus preference to prevent main window stealing focus

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -3879,6 +3879,7 @@ class iRacingControlApp:
         self.auto_save_presets = tk.BooleanVar(value=True)
         self.lock_preset_selection = tk.BooleanVar(value=True)
         self.start_with_windows = tk.BooleanVar(value=False)
+        self.focus_on_start = tk.BooleanVar(value=True)
         self.show_getting_started = tk.BooleanVar(value=True)
         self.clear_target_bind: Optional[str] = None
         self.btn_clear_target_bind: Optional[tk.Button] = None
@@ -3906,6 +3907,7 @@ class iRacingControlApp:
         # Create UI
         self._create_menu()
         self._create_main_ui()
+        self._apply_startup_focus_mode()
         self._update_voice_controls()
         self.root.after(300, self._maybe_show_getting_started)
 
@@ -3945,6 +3947,12 @@ class iRacingControlApp:
     def _on_startup_toggle(self) -> None:
         self._apply_startup_preference(notify=True)
         self.schedule_save()
+
+    def _apply_startup_focus_mode(self) -> None:
+        """Lower the window after startup if focus stealing is disabled."""
+        if self.focus_on_start.get():
+            return
+        self.root.after(250, self.root.lower)
 
     def _voice_tuning_config(self) -> Dict[str, Any]:
         """Return sanitized voice tuning configuration from the UI."""
@@ -4344,6 +4352,13 @@ class iRacingControlApp:
             text="Start with Windows",
             variable=self.start_with_windows,
             command=self._on_startup_toggle
+        ).pack(anchor="w", padx=8, pady=2)
+
+        tk.Checkbutton(
+            stability_frame,
+            text="Focus app window on startup/restart",
+            variable=self.focus_on_start,
+            command=self.schedule_save
         ).pack(anchor="w", padx=8, pady=2)
 
         tk.Checkbutton(
@@ -6212,6 +6227,7 @@ class iRacingControlApp:
             "auto_save_presets": self.auto_save_presets.get(),
             "lock_preset_selection": self.lock_preset_selection.get(),
             "start_with_windows": self.start_with_windows.get(),
+            "focus_on_start": self.focus_on_start.get(),
             "keep_trying_targets": self.keep_trying_targets.get(),
             "show_scan_popup": self.show_scan_popup.get(),
             "show_getting_started": self.show_getting_started.get(),
@@ -6275,6 +6291,7 @@ class iRacingControlApp:
         self.auto_save_presets.set(data.get("auto_save_presets", True))
         self.lock_preset_selection.set(data.get("lock_preset_selection", True))
         self.start_with_windows.set(data.get("start_with_windows", False))
+        self.focus_on_start.set(data.get("focus_on_start", True))
         self.keep_trying_targets.set(data.get("keep_trying_targets", True))
         self.show_scan_popup.set(data.get("show_scan_popup", False))
         self.show_getting_started.set(data.get("show_getting_started", True))

--- a/FINALOKJP.py
+++ b/FINALOKJP.py
@@ -3879,6 +3879,7 @@ class iRacingControlApp:
         self.auto_save_presets = tk.BooleanVar(value=True)
         self.lock_preset_selection = tk.BooleanVar(value=True)
         self.start_with_windows = tk.BooleanVar(value=False)
+        self.focus_on_start = tk.BooleanVar(value=True)
         self.show_getting_started = tk.BooleanVar(value=True)
         self.clear_target_bind: Optional[str] = None
         self.btn_clear_target_bind: Optional[tk.Button] = None
@@ -3906,6 +3907,7 @@ class iRacingControlApp:
         # Create UI
         self._create_menu()
         self._create_main_ui()
+        self._apply_startup_focus_mode()
         self._update_voice_controls()
         self.root.after(300, self._maybe_show_getting_started)
 
@@ -3945,6 +3947,12 @@ class iRacingControlApp:
     def _on_startup_toggle(self) -> None:
         self._apply_startup_preference(notify=True)
         self.schedule_save()
+
+    def _apply_startup_focus_mode(self) -> None:
+        """Lower the window after startup if focus stealing is disabled."""
+        if self.focus_on_start.get():
+            return
+        self.root.after(250, self.root.lower)
 
     def _voice_tuning_config(self) -> Dict[str, Any]:
         """Return sanitized voice tuning configuration from the UI."""
@@ -4344,6 +4352,13 @@ class iRacingControlApp:
             text="Windowsと一緒に開始",
             variable=self.start_with_windows,
             command=self._on_startup_toggle
+        ).pack(anchor="w", padx=8, pady=2)
+
+        tk.Checkbutton(
+            stability_frame,
+            text="起動/再起動時にアプリを前面表示",
+            variable=self.focus_on_start,
+            command=self.schedule_save
         ).pack(anchor="w", padx=8, pady=2)
 
         tk.Checkbutton(
@@ -6212,6 +6227,7 @@ class iRacingControlApp:
             "auto_save_presets": self.auto_save_presets.get(),
             "lock_preset_selection": self.lock_preset_selection.get(),
             "start_with_windows": self.start_with_windows.get(),
+            "focus_on_start": self.focus_on_start.get(),
             "keep_trying_targets": self.keep_trying_targets.get(),
             "show_scan_popup": self.show_scan_popup.get(),
             "show_getting_started": self.show_getting_started.get(),
@@ -6275,6 +6291,7 @@ class iRacingControlApp:
         self.auto_save_presets.set(data.get("auto_save_presets", True))
         self.lock_preset_selection.set(data.get("lock_preset_selection", True))
         self.start_with_windows.set(data.get("start_with_windows", False))
+        self.focus_on_start.set(data.get("focus_on_start", True))
         self.keep_trying_targets.set(data.get("keep_trying_targets", True))
         self.show_scan_popup.set(data.get("show_scan_popup", False))
         self.show_getting_started.set(data.get("show_getting_started", True))

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -3870,6 +3870,7 @@ class iRacingControlApp:
         self.auto_save_presets = tk.BooleanVar(value=True)
         self.lock_preset_selection = tk.BooleanVar(value=True)
         self.start_with_windows = tk.BooleanVar(value=False)
+        self.focus_on_start = tk.BooleanVar(value=True)
         self.show_getting_started = tk.BooleanVar(value=True)
         self.clear_target_bind: Optional[str] = None
         self.btn_clear_target_bind: Optional[tk.Button] = None
@@ -3897,6 +3898,7 @@ class iRacingControlApp:
         # Create UI
         self._create_menu()
         self._create_main_ui()
+        self._apply_startup_focus_mode()
         self._update_voice_controls()
         self.root.after(300, self._maybe_show_getting_started)
 
@@ -3936,6 +3938,12 @@ class iRacingControlApp:
     def _on_startup_toggle(self) -> None:
         self._apply_startup_preference(notify=True)
         self.schedule_save()
+
+    def _apply_startup_focus_mode(self) -> None:
+        """Lower the window after startup if focus stealing is disabled."""
+        if self.focus_on_start.get():
+            return
+        self.root.after(250, self.root.lower)
 
     def _voice_tuning_config(self) -> Dict[str, Any]:
         """Return sanitized voice tuning configuration from the UI."""
@@ -4335,6 +4343,13 @@ class iRacingControlApp:
             text="Iniciar com o Windows",
             variable=self.start_with_windows,
             command=self._on_startup_toggle
+        ).pack(anchor="w", padx=8, pady=2)
+
+        tk.Checkbutton(
+            stability_frame,
+            text="Focar a janela do app ao iniciar/reiniciar",
+            variable=self.focus_on_start,
+            command=self.schedule_save
         ).pack(anchor="w", padx=8, pady=2)
 
         tk.Checkbutton(
@@ -6203,6 +6218,7 @@ class iRacingControlApp:
             "auto_save_presets": self.auto_save_presets.get(),
             "lock_preset_selection": self.lock_preset_selection.get(),
             "start_with_windows": self.start_with_windows.get(),
+            "focus_on_start": self.focus_on_start.get(),
             "keep_trying_targets": self.keep_trying_targets.get(),
             "show_scan_popup": self.show_scan_popup.get(),
             "show_getting_started": self.show_getting_started.get(),
@@ -6266,6 +6282,7 @@ class iRacingControlApp:
         self.auto_save_presets.set(data.get("auto_save_presets", True))
         self.lock_preset_selection.set(data.get("lock_preset_selection", True))
         self.start_with_windows.set(data.get("start_with_windows", False))
+        self.focus_on_start.set(data.get("focus_on_start", True))
         self.keep_trying_targets.set(data.get("keep_trying_targets", True))
         self.show_scan_popup.set(data.get("show_scan_popup", False))
         self.show_getting_started.set(data.get("show_getting_started", True))


### PR DESCRIPTION
### Motivation
- Provide a user-configurable option so the app can start or restart unobtrusively without stealing focus from other windows.
- Support the preference across English, Japanese and Portuguese UI variants and persist it across runs.

### Description
- Introduced a new Tk boolean variable `self.focus_on_start` (default `True`) in the app state to represent the startup focus preference across `FINALOKEN.py`, `FINALOKJP.py`, and `FINALOKPTBR.py`.
- Added a Checkbutton to the Options UI labeled "Focus app window on startup/restart" (localized per file) bound to `self.focus_on_start` that triggers `schedule_save` on change.
- Persisted the setting by adding `"focus_on_start"` to the saved config in `save_config` and restoring it in `load_config` with `self.focus_on_start.set(data.get("focus_on_start", True))`.
- Implemented `_apply_startup_focus_mode()` which calls `self.root.after(250, self.root.lower)` when `self.focus_on_start` is `False`, and invoked this method after the main UI is created in the app initialization.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696912f180c0832a9702e8143b05cc2b)