### PR TITLE
Update preset clear flow to delete and recreate empty preset (EN/PT-BR/JP)

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -5338,14 +5338,10 @@ class iRacingControlApp:
             ):
                 return
 
-            self.saved_presets[car][track] = {
-                "active_vars": None,
-                "tabs": {},
-                "combo": {}
-            }
-
+            del self.saved_presets[car][track]
             self.save_config()
-            self.update_preset_ui()
+            self.rebuild_tabs(list(self.active_vars))
+            self._save_preset_for_pair(car, track, show_message=False)
 
     def _build_preset_values_payload(self) -> Dict[str, Any]:
         """Build a values-only payload for preset sharing."""

--- a/FINALOKJP.py
+++ b/FINALOKJP.py
@@ -5338,14 +5338,10 @@ class iRacingControlApp:
             ):
                 return
 
-            self.saved_presets[car][track] = {
-                "active_vars": None,
-                "tabs": {},
-                "combo": {}
-            }
-
+            del self.saved_presets[car][track]
             self.save_config()
-            self.update_preset_ui()
+            self.rebuild_tabs(list(self.active_vars))
+            self._save_preset_for_pair(car, track, show_message=False)
 
     def _build_preset_values_payload(self) -> Dict[str, Any]:
         """Build a values-only payload for preset sharing."""

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -5329,14 +5329,10 @@ class iRacingControlApp:
             ):
                 return
 
-            self.saved_presets[car][track] = {
-                "active_vars": None,
-                "tabs": {},
-                "combo": {}
-            }
-
+            del self.saved_presets[car][track]
             self.save_config()
-            self.update_preset_ui()
+            self.rebuild_tabs(list(self.active_vars))
+            self._save_preset_for_pair(car, track, show_message=False)
 
     def _build_preset_values_payload(self) -> Dict[str, Any]:
         """Build a values-only payload for preset sharing."""


### PR DESCRIPTION
### Motivation
- Replace the previous behavior that zeroed fields in `saved_presets[car][track]` with a delete-and-recreate flow to ensure clearing a preset fully removes the old entry and yields a consistent empty skeleton.
- Force tabs to be rebuilt so the UI reflects the cleared preset state and active variables.

### Description
- In `action_clear_preset` for the English, Portuguese-BR, and Japanese builds, replace the assignment of an empty preset with `del self.saved_presets[car][track]`.
- After deletion call `self.save_config()`, `self.rebuild_tabs(list(self.active_vars))`, and `self._save_preset_for_pair(car, track, show_message=False)` to recreate an empty preset skeleton and update UI state.
- Applied the same change to `FINALOKEN.py`, `FINALOKPTBR.py`, and `FINALOKJP.py`.

### Testing
- Ran `python FINALOKEN.py` which exited with `ModuleNotFoundError: No module named 'keyboard'`.
- Ran `python FINALOKPTBR.py` which exited with `ModuleNotFoundError: No module named 'keyboard'`.
- Ran `python FINALOKJP.py` which exited with `ModuleNotFoundError: No module named 'keyboard'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69691c78c904832a98ec8365b454cf4b)