### PR TITLE
Disable hotkey/joystick registration outside RUNNING mode

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -4999,14 +4999,11 @@ class iRacingControlApp:
                 text="Mode: CONFIG (Click to Save & Run)",
                 bg="orange"
             )
-            input_manager.active = False
-            self._clear_keyboard_hotkeys()
-            voice_listener.set_enabled(False)
+            self.register_current_listeners()
         else:
             # Switch to RUNNING
             self.app_state = "RUNNING"
             self.btn_mode.config(text="Mode: RUNNING", bg="#90ee90")
-            input_manager.active = True
             self.register_current_listeners()
 
         # Update tab editing states
@@ -6844,6 +6841,7 @@ class iRacingControlApp:
         self._clear_keyboard_hotkeys()
         input_manager.listeners.clear()
         voice_phrases: Dict[str, Callable] = {}
+        allow_input = (self.app_state == "RUNNING")
 
         # Register individual tab presets
         for var_name, tab in self.tabs.items():
@@ -6862,7 +6860,7 @@ class iRacingControlApp:
                     continue
 
                 action = self._make_single_action(controller, target)
-                if bind:
+                if bind and allow_input:
                     if bind.startswith("KEY:"):
                         key_name = bind.split(":", 1)[1].lower()
                         handle = keyboard.add_hotkey(key_name, action)
@@ -6883,7 +6881,7 @@ class iRacingControlApp:
                 values = preset.get("vals", {})
 
                 action = self._make_combo_action(values)
-                if bind:
+                if bind and allow_input:
                     if bind.startswith("KEY:"):
                         key_name = bind.split(":", 1)[1].lower()
                         handle = keyboard.add_hotkey(key_name, action)
@@ -6897,7 +6895,7 @@ class iRacingControlApp:
 
         self.voice_phrase_map = voice_phrases
 
-        if self.clear_target_bind:
+        if self.clear_target_bind and allow_input:
             action = self.clear_all_targets
             if self.clear_target_bind.startswith("KEY:"):
                 key_name = self.clear_target_bind.split(":", 1)[1].lower()
@@ -6906,7 +6904,7 @@ class iRacingControlApp:
             else:
                 input_manager.listeners[self.clear_target_bind] = action
 
-        if self.manual_rescan_bind:
+        if self.manual_rescan_bind and allow_input:
             action = self.manual_restart_scan
             if self.manual_rescan_bind.startswith("KEY:"):
                 key_name = self.manual_rescan_bind.split(":", 1)[1].lower()
@@ -6915,7 +6913,7 @@ class iRacingControlApp:
             else:
                 input_manager.listeners[self.manual_rescan_bind] = action
 
-        input_manager.active = (self.app_state == "RUNNING")
+        input_manager.active = allow_input
         if self.app_state != "RUNNING":
             voice_listener.set_enabled(False)
         elif self.use_voice.get():

--- a/FINALOKJP.py
+++ b/FINALOKJP.py
@@ -4999,14 +4999,11 @@ class iRacingControlApp:
                 text="モード: 設定（クリックで保存＆実行）",
                 bg="orange"
             )
-            input_manager.active = False
-            self._clear_keyboard_hotkeys()
-            voice_listener.set_enabled(False)
+            self.register_current_listeners()
         else:
             # Switch to RUNNING
             self.app_state = "RUNNING"
             self.btn_mode.config(text="モード: 実行中", bg="#90ee90")
-            input_manager.active = True
             self.register_current_listeners()
 
         # Update tab editing states
@@ -6850,6 +6847,7 @@ class iRacingControlApp:
         self._clear_keyboard_hotkeys()
         input_manager.listeners.clear()
         voice_phrases: Dict[str, Callable] = {}
+        allow_input = (self.app_state == "RUNNING")
 
         # Register individual tab presets
         for var_name, tab in self.tabs.items():
@@ -6868,7 +6866,7 @@ class iRacingControlApp:
                     continue
 
                 action = self._make_single_action(controller, target)
-                if bind:
+                if bind and allow_input:
                     if bind.startswith("KEY:"):
                         key_name = bind.split(":", 1)[1].lower()
                         handle = keyboard.add_hotkey(key_name, action)
@@ -6889,7 +6887,7 @@ class iRacingControlApp:
                 values = preset.get("vals", {})
 
                 action = self._make_combo_action(values)
-                if bind:
+                if bind and allow_input:
                     if bind.startswith("KEY:"):
                         key_name = bind.split(":", 1)[1].lower()
                         handle = keyboard.add_hotkey(key_name, action)
@@ -6903,7 +6901,7 @@ class iRacingControlApp:
 
         self.voice_phrase_map = voice_phrases
 
-        if self.clear_target_bind:
+        if self.clear_target_bind and allow_input:
             action = self.clear_all_targets
             if self.clear_target_bind.startswith("KEY:"):
                 key_name = self.clear_target_bind.split(":", 1)[1].lower()
@@ -6912,7 +6910,7 @@ class iRacingControlApp:
             else:
                 input_manager.listeners[self.clear_target_bind] = action
 
-        if self.manual_rescan_bind:
+        if self.manual_rescan_bind and allow_input:
             action = self.manual_restart_scan
             if self.manual_rescan_bind.startswith("KEY:"):
                 key_name = self.manual_rescan_bind.split(":", 1)[1].lower()
@@ -6921,7 +6919,7 @@ class iRacingControlApp:
             else:
                 input_manager.listeners[self.manual_rescan_bind] = action
 
-        input_manager.active = (self.app_state == "RUNNING")
+        input_manager.active = allow_input
         if self.app_state != "RUNNING":
             voice_listener.set_enabled(False)
         elif self.use_voice.get():

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -4990,14 +4990,11 @@ class iRacingControlApp:
                 text="Modo: CONFIG (Clique para salvar e executar)",
                 bg="orange"
             )
-            input_manager.active = False
-            self._clear_keyboard_hotkeys()
-            voice_listener.set_enabled(False)
+            self.register_current_listeners()
         else:
             # Switch to RUNNING
             self.app_state = "RUNNING"
             self.btn_mode.config(text="Modo: EM EXECUÇÃO", bg="#90ee90")
-            input_manager.active = True
             self.register_current_listeners()
 
         # Update tab editing states
@@ -6841,6 +6838,7 @@ class iRacingControlApp:
         self._clear_keyboard_hotkeys()
         input_manager.listeners.clear()
         voice_phrases: Dict[str, Callable] = {}
+        allow_input = (self.app_state == "RUNNING")
 
         # Register individual tab presets
         for var_name, tab in self.tabs.items():
@@ -6859,7 +6857,7 @@ class iRacingControlApp:
                     continue
 
                 action = self._make_single_action(controller, target)
-                if bind:
+                if bind and allow_input:
                     if bind.startswith("KEY:"):
                         key_name = bind.split(":", 1)[1].lower()
                         handle = keyboard.add_hotkey(key_name, action)
@@ -6880,7 +6878,7 @@ class iRacingControlApp:
                 values = preset.get("vals", {})
 
                 action = self._make_combo_action(values)
-                if bind:
+                if bind and allow_input:
                     if bind.startswith("KEY:"):
                         key_name = bind.split(":", 1)[1].lower()
                         handle = keyboard.add_hotkey(key_name, action)
@@ -6894,7 +6892,7 @@ class iRacingControlApp:
 
         self.voice_phrase_map = voice_phrases
 
-        if self.clear_target_bind:
+        if self.clear_target_bind and allow_input:
             action = self.clear_all_targets
             if self.clear_target_bind.startswith("KEY:"):
                 key_name = self.clear_target_bind.split(":", 1)[1].lower()
@@ -6903,7 +6901,7 @@ class iRacingControlApp:
             else:
                 input_manager.listeners[self.clear_target_bind] = action
 
-        if self.manual_rescan_bind:
+        if self.manual_rescan_bind and allow_input:
             action = self.manual_restart_scan
             if self.manual_rescan_bind.startswith("KEY:"):
                 key_name = self.manual_rescan_bind.split(":", 1)[1].lower()
@@ -6912,7 +6910,7 @@ class iRacingControlApp:
             else:
                 input_manager.listeners[self.manual_rescan_bind] = action
 
-        input_manager.active = (self.app_state == "RUNNING")
+        input_manager.active = allow_input
         if self.app_state != "RUNNING":
             voice_listener.set_enabled(False)
         elif self.use_voice.get():


### PR DESCRIPTION
### Motivation
- Prevent hotkeys and joystick listeners from being activated while the app is in `CONFIG` mode to avoid accidental triggers during configuration.
- Ensure voice phrase maps are still built but that voice/listener activation and external input handling are disabled while editing presets or bindings.
- Keep input handling and hotkey registration gated to `RUNNING` so external inputs cannot affect configuration state.

### Description
- Add `allow_input = (self.app_state == "RUNNING")` inside `register_current_listeners` and require it before registering keyboard hotkeys or joystick listeners so bindings are only active in `RUNNING` mode.
- Set `input_manager.active = allow_input` in `register_current_listeners` to centralize input enable/disable logic and keep voice phrase map construction independent of input gating.
- Change `toggle_mode` to call `register_current_listeners()` when switching to `CONFIG` so listeners are cleared and inputs/voice are disabled consistently, removing duplicated manual toggles.
- Apply the same changes to the English, Portuguese (PT-BR), and Japanese builds by updating `FINALOKEN.py`, `FINALOKPTBR.py`, and `FINALOKJP.py`.

### Testing
- Ran `timeout 5 python FINALOKEN.py` which exited with `ModuleNotFoundError: No module named 'keyboard'` due to missing test environment dependency.
- Ran `timeout 5 python FINALOKPTBR.py` which exited with `ModuleNotFoundError: No module named 'keyboard'` for the same reason.
- Ran `timeout 5 python FINALOKJP.py` which exited with `ModuleNotFoundError: No module named 'keyboard'` for the same reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69691d5f14ec832a80db7d5b5aed5dfc)