### PR TITLE
Prevent restarts in CONFIG mode and block off-track command triggers

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -2619,6 +2619,10 @@ class GenericController:
                     cancelled = True
                     break
 
+                if self.app and not self.app._can_trigger_commands():
+                    time.sleep(0.1)
+                    continue
+
                 keep_trying = bool(
                     self.app and self.app.keep_trying_targets.get()
                 )
@@ -5156,6 +5160,8 @@ class iRacingControlApp:
 
     def manual_restart_scan(self):
         """Restart the app and trigger a scan + preset reload."""
+        if self.app_state != "RUNNING":
+            return
         detected_car, detected_track = self._detect_current_car_track()
         restart_car = (
             detected_car
@@ -6667,10 +6673,31 @@ class iRacingControlApp:
 
         return bool(value)
 
+    def _read_ir_value(self, key: str) -> Optional[Any]:
+        """Read a telemetry value from the iRacing SDK."""
+        try:
+            with self.ir_lock:
+                if not getattr(self.ir, "is_initialized", False):
+                    self.ir.startup()
+                if getattr(self.ir, "is_connected", True) is False:
+                    return None
+                return self.ir[key]
+        except Exception:
+            return None
+
     def _can_trigger_commands(self) -> bool:
         """Return True when command execution is allowed by safety settings."""
         if not self.block_offtrack_commands.get():
             return True
+
+        track_surface = self._read_ir_value("PlayerTrackSurface")
+        if isinstance(track_surface, str):
+            surface = track_surface.strip().lower()
+            if surface in {"offtrack", "notinworld", "outofworld"}:
+                return False
+        elif isinstance(track_surface, numbers.Number):
+            if int(track_surface) in {0, 1, 6}:
+                return False
 
         is_on_track = self._read_ir_bool("IsOnTrackCar")
         return True if is_on_track is None else is_on_track

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -2620,6 +2620,10 @@ class GenericController:
                     cancelled = True
                     break
 
+                if self.app and not self.app._can_trigger_commands():
+                    time.sleep(0.1)
+                    continue
+
                 keep_trying = bool(
                     self.app and self.app.keep_trying_targets.get()
                 )
@@ -5147,6 +5151,8 @@ class iRacingControlApp:
 
     def manual_restart_scan(self):
         """Restart the app and trigger a scan + preset reload."""
+        if self.app_state != "RUNNING":
+            return
         detected_car, detected_track = self._detect_current_car_track()
         restart_car = (
             detected_car
@@ -6664,10 +6670,31 @@ class iRacingControlApp:
 
         return bool(value)
 
+    def _read_ir_value(self, key: str) -> Optional[Any]:
+        """Read a telemetry value from the iRacing SDK."""
+        try:
+            with self.ir_lock:
+                if not getattr(self.ir, "is_initialized", False):
+                    self.ir.startup()
+                if getattr(self.ir, "is_connected", True) is False:
+                    return None
+                return self.ir[key]
+        except Exception:
+            return None
+
     def _can_trigger_commands(self) -> bool:
         """Return True when command execution is allowed by safety settings."""
         if not self.block_offtrack_commands.get():
             return True
+
+        track_surface = self._read_ir_value("PlayerTrackSurface")
+        if isinstance(track_surface, str):
+            surface = track_surface.strip().lower()
+            if surface in {"offtrack", "notinworld", "outofworld"}:
+                return False
+        elif isinstance(track_surface, numbers.Number):
+            if int(track_surface) in {0, 1, 6}:
+                return False
 
         is_on_track = self._read_ir_bool("IsOnTrackCar")
         return True if is_on_track is None else is_on_track


### PR DESCRIPTION
### Motivation
- Avoid accidental application restarts triggered by manual-rescan hotkeys while the UI is in CONFIG mode. 
- Prevent the app from attempting to apply control changes when the driver is clearly off-track or out-of-world. 
- Improve off-track detection by consulting `PlayerTrackSurface` telemetry in addition to `IsOnTrackCar`.

### Description
- Added a helper `def _read_ir_value(key: str) -> Optional[Any]` and used it to inspect `PlayerTrackSurface` before allowing commands. 
- Extended `_can_trigger_commands` to treat certain `PlayerTrackSurface` string values and numeric codes (e.g., off-track / out-of-world) as disallowing command execution. 
- Guarded `manual_restart_scan` to return immediately when `app_state != "RUNNING"` to prevent restarts while configuring bindings. 
- Updated the target adjustment loop to pause/skip attempts when `_can_trigger_commands()` is false, avoiding unintended key presses while off-track. 
- Changes applied to all language builds: `FINALOKEN.py`, `FINALOKPTBR.py`, and `FINALOKJP.py`.

### Testing
- Compiled `FINALOKEN.py` with `python -m py_compile FINALOKEN.py` and it succeeded. 
- Compiled `FINALOKPTBR.py` with `python -m py_compile FINALOKPTBR.py` and it succeeded. 
- Compiled `FINALOKJP.py` with `python -m py_compile FINALOKJP.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696921ace6f8832a81532bc164a8b19e)