### PR TITLE
Use IsOnTrack/IsOnTrackCar flags for off-track command gating

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -6689,18 +6689,9 @@ class iRacingControlApp:
         """Return True when command execution is allowed by safety settings."""
         if not self.block_offtrack_commands.get():
             return True
-
-        track_surface = self._read_ir_value("PlayerTrackSurface")
-        if isinstance(track_surface, str):
-            surface = track_surface.strip().lower()
-            if surface in {"offtrack", "notinworld", "outofworld"}:
-                return False
-        elif isinstance(track_surface, numbers.Number):
-            if int(track_surface) in {0, 1, 6}:
-                return False
-
-        is_on_track = self._read_ir_bool("IsOnTrackCar")
-        return True if is_on_track is None else is_on_track
+        is_on_track = self._bool_from_keys(["IsOnTrack"])
+        is_on_track_car = self._bool_from_keys(["IsOnTrackCar"])
+        return is_on_track or is_on_track_car
 
     def _make_single_action(self, controller: GenericController, target: float):
         """Create an action that adjusts a single controller to a target."""

--- a/FINALOKJP.py
+++ b/FINALOKJP.py
@@ -6695,18 +6695,9 @@ class iRacingControlApp:
         """Return True when command execution is allowed by safety settings."""
         if not self.block_offtrack_commands.get():
             return True
-
-        track_surface = self._read_ir_value("PlayerTrackSurface")
-        if isinstance(track_surface, str):
-            surface = track_surface.strip().lower()
-            if surface in {"offtrack", "notinworld", "outofworld"}:
-                return False
-        elif isinstance(track_surface, numbers.Number):
-            if int(track_surface) in {0, 1, 6}:
-                return False
-
-        is_on_track = self._read_ir_bool("IsOnTrackCar")
-        return True if is_on_track is None else is_on_track
+        is_on_track = self._bool_from_keys(["IsOnTrack"])
+        is_on_track_car = self._bool_from_keys(["IsOnTrackCar"])
+        return is_on_track or is_on_track_car
 
     def _make_single_action(self, controller: GenericController, target: float):
         """Create an action that adjusts a single controller to a target."""

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -6686,18 +6686,9 @@ class iRacingControlApp:
         """Return True when command execution is allowed by safety settings."""
         if not self.block_offtrack_commands.get():
             return True
-
-        track_surface = self._read_ir_value("PlayerTrackSurface")
-        if isinstance(track_surface, str):
-            surface = track_surface.strip().lower()
-            if surface in {"offtrack", "notinworld", "outofworld"}:
-                return False
-        elif isinstance(track_surface, numbers.Number):
-            if int(track_surface) in {0, 1, 6}:
-                return False
-
-        is_on_track = self._read_ir_bool("IsOnTrackCar")
-        return True if is_on_track is None else is_on_track
+        is_on_track = self._bool_from_keys(["IsOnTrack"])
+        is_on_track_car = self._bool_from_keys(["IsOnTrackCar"])
+        return is_on_track or is_on_track_car
 
     def _make_single_action(self, controller: GenericController, target: float):
         """Create an action that adjusts a single controller to a target."""


### PR DESCRIPTION
### Motivation
- Simplify off-track command gating so commands are only blocked when both `IsOnTrack` and `IsOnTrackCar` are false, avoiding spurious blocking (e.g. in pits) from `PlayerTrackSurface` checks.

### Description
- Replace the previous `PlayerTrackSurface` and numeric checks with `is_on_track = self._bool_from_keys(["IsOnTrack"])` and `is_on_track_car = self._bool_from_keys(["IsOnTrackCar"])` and return `is_on_track or is_on_track_car` in `FINALOKEN.py`, `FINALOKPTBR.py`, and `FINALOKJP.py`.

### Testing
- Ran `timeout 5 python FINALOKEN.py`, `timeout 5 python FINALOKPTBR.py`, and `timeout 5 python FINALOKJP.py`, and all three attempts failed with `ModuleNotFoundError: No module named 'keyboard'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696924638130832a94545595ca0109a9)