### PR TITLE
Fix off-track command blocking based on IsOnTrackCar

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -6689,9 +6689,13 @@ class iRacingControlApp:
         """Return True when command execution is allowed by safety settings."""
         if not self.block_offtrack_commands.get():
             return True
-        is_on_track = self._bool_from_keys(["IsOnTrack"])
-        is_on_track_car = self._bool_from_keys(["IsOnTrackCar"])
-        return is_on_track or is_on_track_car
+        is_on_track_car = self._read_ir_value("IsOnTrackCar")
+        if is_on_track_car is not None:
+            return bool(is_on_track_car)
+        is_on_track = self._read_ir_value("IsOnTrack")
+        if is_on_track is not None:
+            return bool(is_on_track)
+        return False
 
     def _make_single_action(self, controller: GenericController, target: float):
         """Create an action that adjusts a single controller to a target."""

--- a/FINALOKJP.py
+++ b/FINALOKJP.py
@@ -6695,9 +6695,13 @@ class iRacingControlApp:
         """Return True when command execution is allowed by safety settings."""
         if not self.block_offtrack_commands.get():
             return True
-        is_on_track = self._bool_from_keys(["IsOnTrack"])
-        is_on_track_car = self._bool_from_keys(["IsOnTrackCar"])
-        return is_on_track or is_on_track_car
+        is_on_track_car = self._read_ir_value("IsOnTrackCar")
+        if is_on_track_car is not None:
+            return bool(is_on_track_car)
+        is_on_track = self._read_ir_value("IsOnTrack")
+        if is_on_track is not None:
+            return bool(is_on_track)
+        return False
 
     def _make_single_action(self, controller: GenericController, target: float):
         """Create an action that adjusts a single controller to a target."""

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -6686,9 +6686,13 @@ class iRacingControlApp:
         """Return True when command execution is allowed by safety settings."""
         if not self.block_offtrack_commands.get():
             return True
-        is_on_track = self._bool_from_keys(["IsOnTrack"])
-        is_on_track_car = self._bool_from_keys(["IsOnTrackCar"])
-        return is_on_track or is_on_track_car
+        is_on_track_car = self._read_ir_value("IsOnTrackCar")
+        if is_on_track_car is not None:
+            return bool(is_on_track_car)
+        is_on_track = self._read_ir_value("IsOnTrack")
+        if is_on_track is not None:
+            return bool(is_on_track)
+        return False
 
     def _make_single_action(self, controller: GenericController, target: float):
         """Create an action that adjusts a single controller to a target."""


### PR DESCRIPTION
### Motivation
- The `Disable commands when IsOnTrackCar is false` option was not preventing command sends when the driver was out of the car because the gating logic used a broad truthiness check that could be satisfied even when driver telemetry was unavailable.  
- Prefer explicit telemetry reads for `IsOnTrackCar` and fall back to `IsOnTrack` to avoid false positives when values are missing or the driver is not present.  

### Description
- Replace the `_bool_from_keys`-based check with direct calls to `_read_ir_value` for `IsOnTrackCar` then `IsOnTrack`, returning `False` if neither telemetry value is available.  
- Apply the same fix to the English, Portuguese, and Japanese single-file builds (`FINALOKEN.py`, `FINALOKPTBR.py`, `FINALOKJP.py`).  
- Keep behavior unchanged when the `block_offtrack_commands` option is disabled by returning `True` early.  

### Testing
- Compiled the three modified files with `python -m py_compile FINALOKEN.py`, `python -m py_compile FINALOKPTBR.py`, and `python -m py_compile FINALOKJP.py`, and all compilations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69692830c488832a94ef383496d9fea8)