### PR TITLE
Speed up bot timing profile

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -570,8 +570,8 @@ def _compute_timing(is_float: bool = False) -> Tuple[float, float]:
         press_ms = 150
         interval_ms = 200
     elif profile == "bot":
-        press_ms = 1
-        interval_ms = 1
+        press_ms = 0
+        interval_ms = 0
     elif profile == "bot_safe":
         press_ms = 12
         interval_ms = 6
@@ -590,7 +590,7 @@ def _compute_timing(is_float: bool = False) -> Tuple[float, float]:
 
     # Ensure minimum values, allowing extremely low latency for bot modes
     if profile == "bot":
-        min_value = 1
+        min_value = 0
     elif profile == "bot_safe":
         min_value = 5
     else:


### PR DESCRIPTION
### Motivation
- Reduce input latency for the "bot" behavior profile so simulated key pulses are near-instant for faster automation.

### Description
- In `FINALOKEN.py` inside `_compute_timing`, set `press_ms` and `interval_ms` to `0` for the `bot` profile and allow a `min_value` of `0` so computed timings can be effectively instantaneous.

### Testing
- Successfully ran `python -m py_compile FINALOKEN.py`, `python -m py_compile FINALOKPTBR.py`, and `python -m py_compile FINALOKJP.py` (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696932e2a6bc832aada8de70c2bf09e7)