### PR TITLE
Remove extra bot delays in FINALOKEN timing

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -589,17 +589,15 @@ def _compute_timing(is_float: bool = False) -> Tuple[float, float]:
             interval_ms += random.uniform(-rng, rng)
 
     # Ensure minimum values, allowing extremely low latency for bot modes
-    if profile == "bot":
+    if profile in {"bot", "bot_safe"}:
         min_value = 1
-    elif profile == "bot_safe":
-        min_value = 5
     else:
         min_value = 10
     press_ms = max(min_value, press_ms)
     interval_ms = max(min_value, interval_ms)
 
-    # Add extra delay for float variables unless running bot profile
-    if is_float and profile != "bot":
+    # Add extra delay for float variables unless running bot profiles
+    if is_float and profile not in {"bot", "bot_safe"}:
         press_ms += 30
 
     return press_ms / 1000.0, interval_ms / 1000.0


### PR DESCRIPTION
### Motivation
- Align BOT and BOT_SAFE timing behavior so both use the near-zero profile timings and avoid additional safety padding in `FINALOKEN.py`.

### Description
- Update `_compute_timing` so `bot_safe` is treated like `bot` for the minimum timing floor and to skip the extra float-variable padding, changing the checks to use `profile in {"bot", "bot_safe"}` and `profile not in {"bot", "bot_safe"}` respectively.

### Testing
- Ran `python -m py_compile FINALOKEN.py`, `python -m py_compile FINALOKPTBR.py`, and `python -m py_compile FINALOKJP.py`, all of which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696934f4d63c832aa67d9ae8d1e8d120)