### PR TITLE
Revert telemetry stabilization reads

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -2425,42 +2425,6 @@ class GenericController:
         except Exception:
             return None
 
-    def _read_telemetry_stable(
-        self,
-        samples: int = 3,
-        delay_s: float = 0.01
-    ) -> Optional[float]:
-        """
-        Read telemetry multiple times and return a stabilized value.
-
-        For integer telemetry, returns the most common sample (median tiebreak).
-        For float telemetry, returns the average of collected samples.
-        """
-        values: List[float] = []
-        for _ in range(max(1, samples)):
-            value = self.read_telemetry()
-            if value is not None:
-                values.append(float(value))
-            if delay_s > 0:
-                time.sleep(delay_s)
-
-        if not values:
-            return None
-
-        if self.is_float:
-            return sum(values) / len(values)
-
-        rounded = [int(round(v)) for v in values]
-        counts = {}
-        for value in rounded:
-            counts[value] = counts.get(value, 0) + 1
-        max_count = max(counts.values())
-        candidates = [value for value, count in counts.items() if count == max_count]
-        if len(candidates) == 1:
-            return candidates[0]
-        rounded.sort()
-        return rounded[len(rounded) // 2]
-
     def _detect_float_step(self) -> Optional[float]:
         """Detect the minimal float increment by pulsing once and restoring."""
         if not self.is_float:
@@ -2584,7 +2548,7 @@ class GenericController:
         timing_profile = _normalize_timing_config(GLOBAL_TIMING).get("profile", "aggressive")
         is_bot_profile = timing_profile in {"bot", "bot_safe"}
         is_bot_experimental = timing_profile == "bot"
-        read_fn = self._read_telemetry_stable if is_bot_profile else self.read_telemetry
+        read_fn = self.read_telemetry
 
         try:
             while True:
@@ -2761,7 +2725,7 @@ class GenericController:
         if not self.key_increase or not self.key_decrease:
             raise ValueError("Increase/decrease keys must be configured before probing.")
 
-        baseline = self._read_telemetry_stable(samples=3, delay_s=0.01)
+        baseline = self.read_telemetry()
         if baseline is None:
             return None
 
@@ -2775,7 +2739,7 @@ class GenericController:
         def _restore(target_value: float, timing_ms: int):
             """Attempt to revert telemetry back near baseline after a test."""
             for _ in range(5):
-                current = self._read_telemetry_stable(samples=3, delay_s=0.01)
+                current = self.read_telemetry()
                 if current is None:
                     break
                 if not _changed(target_value, current):
@@ -2789,7 +2753,7 @@ class GenericController:
             for _ in range(max(1, confirmation_attempts)):
                 _direct_pulse(self.key_increase, delay_ms, delay_ms)
                 time.sleep(settle_s)
-                updated = self._read_telemetry_stable(samples=3, delay_s=0.01)
+                updated = self.read_telemetry()
                 if _changed(baseline, updated):
                     success_count += 1
                 else:

--- a/FINALOKJP.py
+++ b/FINALOKJP.py
@@ -2427,42 +2427,6 @@ class GenericController:
         except Exception:
             return None
 
-    def _read_telemetry_stable(
-        self,
-        samples: int = 3,
-        delay_s: float = 0.01
-    ) -> Optional[float]:
-        """
-        Read telemetry multiple times and return a stabilized value.
-
-        For integer telemetry, returns the most common sample (median tiebreak).
-        For float telemetry, returns the average of collected samples.
-        """
-        values: List[float] = []
-        for _ in range(max(1, samples)):
-            value = self.read_telemetry()
-            if value is not None:
-                values.append(float(value))
-            if delay_s > 0:
-                time.sleep(delay_s)
-
-        if not values:
-            return None
-
-        if self.is_float:
-            return sum(values) / len(values)
-
-        rounded = [int(round(v)) for v in values]
-        counts = {}
-        for value in rounded:
-            counts[value] = counts.get(value, 0) + 1
-        max_count = max(counts.values())
-        candidates = [value for value, count in counts.items() if count == max_count]
-        if len(candidates) == 1:
-            return candidates[0]
-        rounded.sort()
-        return rounded[len(rounded) // 2]
-
     def _detect_float_step(self) -> Optional[float]:
         """Detect the minimal float increment by pulsing once and restoring."""
         if not self.is_float:
@@ -2586,7 +2550,7 @@ class GenericController:
         timing_profile = _normalize_timing_config(GLOBAL_TIMING).get("profile", "aggressive")
         is_bot_profile = timing_profile in {"bot", "bot_safe"}
         is_bot_safe = timing_profile == "bot_safe"
-        read_fn = self._read_telemetry_stable if is_bot_profile else self.read_telemetry
+        read_fn = self.read_telemetry
 
         try:
             while True:
@@ -2765,7 +2729,7 @@ class GenericController:
         if not self.key_increase or not self.key_decrease:
             raise ValueError("プローブ前に増加/減少キーを設定してください。")
 
-        baseline = self._read_telemetry_stable(samples=3, delay_s=0.01)
+        baseline = self.read_telemetry()
         if baseline is None:
             return None
 
@@ -2779,7 +2743,7 @@ class GenericController:
         def _restore(target_value: float, timing_ms: int):
             """Attempt to revert telemetry back near baseline after a test."""
             for _ in range(5):
-                current = self._read_telemetry_stable(samples=3, delay_s=0.01)
+                current = self.read_telemetry()
                 if current is None:
                     break
                 if not _changed(target_value, current):
@@ -2793,7 +2757,7 @@ class GenericController:
             for _ in range(max(1, confirmation_attempts)):
                 _direct_pulse(self.key_increase, delay_ms, delay_ms)
                 time.sleep(settle_s)
-                updated = self._read_telemetry_stable(samples=3, delay_s=0.01)
+                updated = self.read_telemetry()
                 if _changed(baseline, updated):
                     success_count += 1
                 else:

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -2428,42 +2428,6 @@ class GenericController:
         except Exception:
             return None
 
-    def _read_telemetry_stable(
-        self,
-        samples: int = 3,
-        delay_s: float = 0.01
-    ) -> Optional[float]:
-        """
-        Read telemetry multiple times and return a stabilized value.
-
-        For integer telemetry, returns the most common sample (median tiebreak).
-        For float telemetry, returns the average of collected samples.
-        """
-        values: List[float] = []
-        for _ in range(max(1, samples)):
-            value = self.read_telemetry()
-            if value is not None:
-                values.append(float(value))
-            if delay_s > 0:
-                time.sleep(delay_s)
-
-        if not values:
-            return None
-
-        if self.is_float:
-            return sum(values) / len(values)
-
-        rounded = [int(round(v)) for v in values]
-        counts = {}
-        for value in rounded:
-            counts[value] = counts.get(value, 0) + 1
-        max_count = max(counts.values())
-        candidates = [value for value, count in counts.items() if count == max_count]
-        if len(candidates) == 1:
-            return candidates[0]
-        rounded.sort()
-        return rounded[len(rounded) // 2]
-
     def _detect_float_step(self) -> Optional[float]:
         """Detect the minimal float increment by pulsing once and restoring."""
         if not self.is_float:
@@ -2587,7 +2551,7 @@ class GenericController:
         timing_profile = _normalize_timing_config(GLOBAL_TIMING).get("profile", "aggressive")
         is_bot_profile = timing_profile in {"bot", "bot_safe"}
         is_bot_safe = timing_profile == "bot_safe"
-        read_fn = self._read_telemetry_stable if is_bot_profile else self.read_telemetry
+        read_fn = self.read_telemetry
 
         try:
             while True:
@@ -2766,7 +2730,7 @@ class GenericController:
         if not self.key_increase or not self.key_decrease:
             raise ValueError("As teclas de aumento/diminuição devem ser configuradas antes da verificação.")
 
-        baseline = self._read_telemetry_stable(samples=3, delay_s=0.01)
+        baseline = self.read_telemetry()
         if baseline is None:
             return None
 
@@ -2780,7 +2744,7 @@ class GenericController:
         def _restore(target_value: float, timing_ms: int):
             """Attempt to revert telemetry back near baseline after a test."""
             for _ in range(5):
-                current = self._read_telemetry_stable(samples=3, delay_s=0.01)
+                current = self.read_telemetry()
                 if current is None:
                     break
                 if not _changed(target_value, current):
@@ -2794,7 +2758,7 @@ class GenericController:
             for _ in range(max(1, confirmation_attempts)):
                 _direct_pulse(self.key_increase, delay_ms, delay_ms)
                 time.sleep(settle_s)
-                updated = self._read_telemetry_stable(samples=3, delay_s=0.01)
+                updated = self.read_telemetry()
                 if _changed(baseline, updated):
                     success_count += 1
                 else:


### PR DESCRIPTION
### Motivation
- The recent stabilized telemetry sampling (`_read_telemetry_stable`) added repeated sampling and short sleeps which slowed down timing-sensitive routines and reduced responsiveness. 
- Revert to direct telemetry reads so timing probes and bot/near-zero profiles operate with minimal latency.

### Description
- Removed use of the stabilized sampling path and restored `read_fn = self.read_telemetry` for bot timing profiles in `GenericController` across `FINALOKEN.py`, `FINALOKJP.py`, and `FINALOKPTBR.py`.
- Replaced calls to `_read_telemetry_stable(...)` with direct `self.read_telemetry()` in the `find_minimum_effective_timing` probe (baseline, restore, and updated checks) in all three language builds.
- Deleted the previously added `_read_telemetry_stable` helper code paths (implemented removal by deleting the helper and its uses in the three files).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69696d7642a8832ab0a3abc55fa223a9)