### PR TITLE
Update README for 6.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **Uninstall vJoy to use this app!**
 
-Download it here: https://github.com/nishizumi-maho/Nishizumi-Control/releases/tag/V5.i.5
+Download it here: https://github.com/nishizumi-maho/Nishizumi-Control/releases/tag/V6.0.0
 
 
 An accessibility-focused control manager for iRacing that provides:
@@ -13,12 +13,15 @@ An accessibility-focused control manager for iRacing that provides:
 - Per-car and per-track preset management
 - Macro/combo system for quick adjustments
 
-![Version](https://img.shields.io/badge/version-5.0.0-blue.svg)
+![Version](https://img.shields.io/badge/version-6.0.0-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-Windows-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 
 ## Overview
 Dominant Control is a single-file application (`FINALOK.py`) that manages iRacing’s driver-adjustable controls. It includes optional text-to-speech feedback, joystick support, and offline voice control when the related dependencies are installed.
+
+## Release 6.0.0 Highlights
+- See the [release notes](https://github.com/nishizumi-maho/Nishizumi-Control/releases/tag/V6.0.0) for the full change list.
 
 ## Release 5.0.0 Highlights
 - **Refreshed layout:** new Main/Options tabs with a guided Step 1–3 setup flow for car/track, device confirmation, and control scanning.


### PR DESCRIPTION
### Motivation
- Bump the public documentation to reference the new `6.0.0` release and provide a link to the release notes.

### Description
- Edited `README.md` to replace the download URL with the `V6.0.0` release, update the version badge to `6.0.0`, and add a `Release 6.0.0 Highlights` section linking to the release notes while keeping the existing `5.0.0` highlights.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697b99ba44832ab53919e09b6dc66d)