### PR TITLE
Prevent duplicate hotkey bindings

### DIFF
--- a/FINALOKJP.py
+++ b/FINALOKJP.py
@@ -3025,6 +3025,14 @@ class ControlTab(tk.Frame):
 
     def _config_bind_button(self, button: tk.Button, data_store: Dict[str, Any]):
         """Configure binding button behavior."""
+        def apply_button_state(bind_code: Optional[str]) -> None:
+            default_text = data_store.get("default_bind_text", "バインド設定")
+            if bind_code:
+                bg_color = "#90ee90" if "JOY" in bind_code else "#ADD8E6"
+                button.config(text=bind_code, bg=bg_color)
+            else:
+                button.config(text=default_text, bg="#f0f0f0")
+
         def on_click():
             if self.app.app_state != "CONFIG":
                 messagebox.showinfo("通知", "先にCONFIGモードにしてください。")
@@ -3035,15 +3043,23 @@ class ControlTab(tk.Frame):
             button.config(text="...", bg="yellow")
             self.update_idletasks()
 
+            previous_bind = data_store.get("bind")
             code = input_manager.capture_any_input()
 
             if code and code != "CANCEL":
+                if not self.app.is_hotkey_available(code, current=previous_bind):
+                    messagebox.showwarning(
+                        "ホットキー使用中",
+                        "そのホットキーは既に使用されています。"
+                        "既存のバインドを解除してから再設定してください。"
+                    )
+                    apply_button_state(previous_bind)
+                    return
                 data_store["bind"] = code
-                bg_color = "#90ee90" if "JOY" in code else "#ADD8E6"
-                button.config(text=code, bg=bg_color)
+                apply_button_state(code)
             elif code == "CANCEL":
                 data_store["bind"] = None
-                button.config(text="バインド設定", bg="#f0f0f0")
+                apply_button_state(None)
 
             self.app.schedule_preset_save()
 
@@ -3090,7 +3106,8 @@ class ControlTab(tk.Frame):
             "bind": None,
             "is_reset": is_reset,
             "voice_entry": voice_entry,
-            "delete_button": None
+            "delete_button": None,
+            "default_bind_text": "バインド設定"
         }
         self._config_bind_button(bind_button, row_data)
 
@@ -3431,6 +3448,14 @@ class ComboTab(tk.Frame):
 
     def _config_bind_button(self, button: tk.Button, data_store: Dict[str, Any]):
         """Configure binding button behavior."""
+        def apply_button_state(bind_code: Optional[str]) -> None:
+            default_text = data_store.get("default_bind_text", "バインド設定")
+            if bind_code:
+                bg_color = "#90ee90" if "JOY" in bind_code else "#ADD8E6"
+                button.config(text=bind_code, bg=bg_color)
+            else:
+                button.config(text=default_text, bg="#f0f0f0")
+
         def on_click():
             if self.app.app_state != "CONFIG":
                 messagebox.showinfo("通知", "先にCONFIGモードにしてください。")
@@ -3441,15 +3466,23 @@ class ComboTab(tk.Frame):
             button.config(text="...", bg="yellow")
             self.update_idletasks()
 
+            previous_bind = data_store.get("bind")
             code = input_manager.capture_any_input()
 
             if code and code != "CANCEL":
+                if not self.app.is_hotkey_available(code, current=previous_bind):
+                    messagebox.showwarning(
+                        "ホットキー使用中",
+                        "そのホットキーは既に使用されています。"
+                        "既存のバインドを解除してから再設定してください。"
+                    )
+                    apply_button_state(previous_bind)
+                    return
                 data_store["bind"] = code
-                bg_color = "#90ee90" if "JOY" in code else "#ADD8E6"
-                button.config(text=code, bg=bg_color)
+                apply_button_state(code)
             elif code == "CANCEL":
                 data_store["bind"] = None
-                button.config(text="バインド設定", bg="#f0f0f0")
+                apply_button_state(None)
 
             self.app.schedule_preset_save()
 
@@ -3478,7 +3511,8 @@ class ComboTab(tk.Frame):
             "bind": None,
             "is_reset": is_reset,
             "voice_entry": None,
-            "delete_button": None
+            "delete_button": None,
+            "default_bind_text": "リセット" if is_reset else "バインド設定"
         }
         self._config_bind_button(bind_button, row_data)
 
@@ -5070,6 +5104,37 @@ class iRacingControlApp:
                 bg="#f0f0f0"
             )
 
+    def _collect_hotkey_binds(self) -> List[str]:
+        binds: List[str] = []
+        for tab in self.tabs.values():
+            for row in tab.preset_rows:
+                bind = row.get("bind")
+                if bind:
+                    binds.append(bind)
+        if self.combo_tab:
+            for row in self.combo_tab.preset_rows:
+                bind = row.get("bind")
+                if bind:
+                    binds.append(bind)
+        if self.clear_target_bind:
+            binds.append(self.clear_target_bind)
+        if self.manual_rescan_bind:
+            binds.append(self.manual_rescan_bind)
+        return binds
+
+    def is_hotkey_available(
+        self,
+        code: Optional[str],
+        current: Optional[str] = None
+    ) -> bool:
+        """Return True when the hotkey is unused (or only used by current)."""
+        if not code:
+            return True
+        matches = sum(1 for bind in self._collect_hotkey_binds() if bind == code)
+        if current and code == current:
+            return matches <= 1
+        return matches == 0
+
     def _set_clear_target_bind(self):
         """Capture an optional hotkey for clearing target attempts."""
         if self.app_state != "CONFIG":
@@ -5084,6 +5149,14 @@ class iRacingControlApp:
         code = input_manager.capture_any_input()
 
         if code and code != "CANCEL":
+            if not self.is_hotkey_available(code, current=self.clear_target_bind):
+                messagebox.showwarning(
+                    "ホットキー使用中",
+                    "そのホットキーは既に使用されています。"
+                    "既存のバインドを解除してから再設定してください。"
+                )
+                self._refresh_clear_target_bind_button()
+                return
             self.clear_target_bind = code
         elif code == "CANCEL":
             self.clear_target_bind = None
@@ -5113,6 +5186,14 @@ class iRacingControlApp:
         code = input_manager.capture_any_input()
 
         if code and code != "CANCEL":
+            if not self.is_hotkey_available(code, current=self.manual_rescan_bind):
+                messagebox.showwarning(
+                    "ホットキー使用中",
+                    "そのホットキーは既に使用されています。"
+                    "既存のバインドを解除してから再設定してください。"
+                )
+                self._refresh_manual_rescan_bind_button()
+                return
             self.manual_rescan_bind = code
         elif code == "CANCEL":
             self.manual_rescan_bind = None

--- a/FINALOKPTBR.py
+++ b/FINALOKPTBR.py
@@ -3016,6 +3016,14 @@ class ControlTab(tk.Frame):
 
     def _config_bind_button(self, button: tk.Button, data_store: Dict[str, Any]):
         """Configure binding button behavior."""
+        def apply_button_state(bind_code: Optional[str]) -> None:
+            default_text = data_store.get("default_bind_text", "Definir atalho")
+            if bind_code:
+                bg_color = "#90ee90" if "JOY" in bind_code else "#ADD8E6"
+                button.config(text=bind_code, bg=bg_color)
+            else:
+                button.config(text=default_text, bg="#f0f0f0")
+
         def on_click():
             if self.app.app_state != "CONFIG":
                 messagebox.showinfo("Aviso", "Entre no modo CONFIG primeiro.")
@@ -3026,15 +3034,23 @@ class ControlTab(tk.Frame):
             button.config(text="...", bg="yellow")
             self.update_idletasks()
 
+            previous_bind = data_store.get("bind")
             code = input_manager.capture_any_input()
 
             if code and code != "CANCEL":
+                if not self.app.is_hotkey_available(code, current=previous_bind):
+                    messagebox.showwarning(
+                        "Atalho em uso",
+                        "Esse atalho já está em uso. "
+                        "Remova o vínculo existente antes de reutilizá-lo."
+                    )
+                    apply_button_state(previous_bind)
+                    return
                 data_store["bind"] = code
-                bg_color = "#90ee90" if "JOY" in code else "#ADD8E6"
-                button.config(text=code, bg=bg_color)
+                apply_button_state(code)
             elif code == "CANCEL":
                 data_store["bind"] = None
-                button.config(text="Definir atalho", bg="#f0f0f0")
+                apply_button_state(None)
 
             self.app.schedule_preset_save()
 
@@ -3081,7 +3097,8 @@ class ControlTab(tk.Frame):
             "bind": None,
             "is_reset": is_reset,
             "voice_entry": voice_entry,
-            "delete_button": None
+            "delete_button": None,
+            "default_bind_text": "Definir atalho"
         }
         self._config_bind_button(bind_button, row_data)
 
@@ -3422,6 +3439,14 @@ class ComboTab(tk.Frame):
 
     def _config_bind_button(self, button: tk.Button, data_store: Dict[str, Any]):
         """Configure binding button behavior."""
+        def apply_button_state(bind_code: Optional[str]) -> None:
+            default_text = data_store.get("default_bind_text", "Definir atalho")
+            if bind_code:
+                bg_color = "#90ee90" if "JOY" in bind_code else "#ADD8E6"
+                button.config(text=bind_code, bg=bg_color)
+            else:
+                button.config(text=default_text, bg="#f0f0f0")
+
         def on_click():
             if self.app.app_state != "CONFIG":
                 messagebox.showinfo("Aviso", "Entre no modo CONFIG primeiro.")
@@ -3432,15 +3457,23 @@ class ComboTab(tk.Frame):
             button.config(text="...", bg="yellow")
             self.update_idletasks()
 
+            previous_bind = data_store.get("bind")
             code = input_manager.capture_any_input()
 
             if code and code != "CANCEL":
+                if not self.app.is_hotkey_available(code, current=previous_bind):
+                    messagebox.showwarning(
+                        "Atalho em uso",
+                        "Esse atalho já está em uso. "
+                        "Remova o vínculo existente antes de reutilizá-lo."
+                    )
+                    apply_button_state(previous_bind)
+                    return
                 data_store["bind"] = code
-                bg_color = "#90ee90" if "JOY" in code else "#ADD8E6"
-                button.config(text=code, bg=bg_color)
+                apply_button_state(code)
             elif code == "CANCEL":
                 data_store["bind"] = None
-                button.config(text="Definir atalho", bg="#f0f0f0")
+                apply_button_state(None)
 
             self.app.schedule_preset_save()
 
@@ -3469,7 +3502,8 @@ class ComboTab(tk.Frame):
             "bind": None,
             "is_reset": is_reset,
             "voice_entry": None,
-            "delete_button": None
+            "delete_button": None,
+            "default_bind_text": "RESETAR" if is_reset else "Definir atalho"
         }
         self._config_bind_button(bind_button, row_data)
 
@@ -5061,6 +5095,37 @@ class iRacingControlApp:
                 bg="#f0f0f0"
             )
 
+    def _collect_hotkey_binds(self) -> List[str]:
+        binds: List[str] = []
+        for tab in self.tabs.values():
+            for row in tab.preset_rows:
+                bind = row.get("bind")
+                if bind:
+                    binds.append(bind)
+        if self.combo_tab:
+            for row in self.combo_tab.preset_rows:
+                bind = row.get("bind")
+                if bind:
+                    binds.append(bind)
+        if self.clear_target_bind:
+            binds.append(self.clear_target_bind)
+        if self.manual_rescan_bind:
+            binds.append(self.manual_rescan_bind)
+        return binds
+
+    def is_hotkey_available(
+        self,
+        code: Optional[str],
+        current: Optional[str] = None
+    ) -> bool:
+        """Return True when the hotkey is unused (or only used by current)."""
+        if not code:
+            return True
+        matches = sum(1 for bind in self._collect_hotkey_binds() if bind == code)
+        if current and code == current:
+            return matches <= 1
+        return matches == 0
+
     def _set_clear_target_bind(self):
         """Capture an optional hotkey for clearing target attempts."""
         if self.app_state != "CONFIG":
@@ -5075,6 +5140,14 @@ class iRacingControlApp:
         code = input_manager.capture_any_input()
 
         if code and code != "CANCEL":
+            if not self.is_hotkey_available(code, current=self.clear_target_bind):
+                messagebox.showwarning(
+                    "Atalho em uso",
+                    "Esse atalho já está em uso. "
+                    "Remova o vínculo existente antes de reutilizá-lo."
+                )
+                self._refresh_clear_target_bind_button()
+                return
             self.clear_target_bind = code
         elif code == "CANCEL":
             self.clear_target_bind = None
@@ -5104,6 +5177,14 @@ class iRacingControlApp:
         code = input_manager.capture_any_input()
 
         if code and code != "CANCEL":
+            if not self.is_hotkey_available(code, current=self.manual_rescan_bind):
+                messagebox.showwarning(
+                    "Atalho em uso",
+                    "Esse atalho já está em uso. "
+                    "Remova o vínculo existente antes de reutilizá-lo."
+                )
+                self._refresh_manual_rescan_bind_button()
+                return
             self.manual_rescan_bind = code
         elif code == "CANCEL":
             self.manual_rescan_bind = None


### PR DESCRIPTION
### Motivation

- Prevent users from assigning the same hotkey to multiple actions (presets, combos, and global clear/rescan hotkeys).
- Ensure UI buttons reflect the correct bind state after a cancelled or rejected bind attempt.

### Description

- Added `_collect_hotkey_binds` and `is_hotkey_available` helpers to gather existing binds and check availability.
- Updated `_config_bind_button` in preset/combo UIs to save `previous_bind`, restore button text via `apply_button_state`, and warn/abort when a chosen hotkey is already assigned.
- Enforced uniqueness for the global `clear_target_bind` and `manual_rescan_bind` via availability checks and warning dialogs when attempting to reuse a hotkey.
- Stored a `default_bind_text` in preset/combo `row_data` so buttons restore to the correct localized label; changes applied to English (`FINALOKEN.py`), Japanese (`FINALOKJP.py`), and Portuguese (`FINALOKPTBR.py`) variants.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969868e68e0832a97742f01331bc4b7)