### PR TITLE
Fix DRY/WET combo preset loading

### DIFF
--- a/FINALOKEN.py
+++ b/FINALOKEN.py
@@ -5736,8 +5736,8 @@ class iRacingControlApp:
 
         # Load combo config
         combo_data = data.get("combo")
-        if self.combo_tab and combo_data:
-            self.combo_tab.set_config(combo_data)
+        if self.combo_tab is not None:
+            self.combo_tab.set_config(combo_data or {})
 
         # Load overlay config
         overlay_config = self.saved_presets[car].get("_overlay", {})


### PR DESCRIPTION
### Motivation
- DRY/WET condition switches did not reset or load combo/macro presets when the saved combo config was empty, preventing macros from updating when changing `DRY`/`WET`.

### Description
- In `load_specific_preset` ensure the combo tab always receives a config by calling `self.combo_tab.set_config(combo_data or {})` when `self.combo_tab` exists, so empty saved combo payloads clear/apply macros correctly (`FINALOKEN.py`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ab759af8832a859ee75969626df7)