### PR TITLE
Prevent restart during startup scan

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -5926,6 +5926,7 @@ class iRacingControlApp:
         self,
         *,
         silent_if_unavailable: bool = False,
+        allow_restart: bool = True,
         on_complete: Optional[Callable[[], None]] = None
     ):
         """Scan for dc* driver control variables in current car."""
@@ -5935,7 +5936,12 @@ class iRacingControlApp:
                     self.root.after(0, on_complete)
                 return
 
-            if self.auto_restart_on_rescan.get() and self.scans_since_restart >= 1:
+            if (
+                allow_restart
+                and self.auto_restart_on_rescan.get()
+                and self.scans_since_restart >= 1
+                and not self.pending_scan_on_start
+            ):
                 detected_car, detected_track = self._detect_current_car_track()
                 restart_car = (
                     detected_car
@@ -6536,7 +6542,8 @@ class iRacingControlApp:
             self.root.after(
                 50,
                 lambda: self.scan_driver_controls(
-                    silent_if_unavailable=self._pending_scan_silent
+                    silent_if_unavailable=self._pending_scan_silent,
+                    allow_restart=False
                 )
             )
 


### PR DESCRIPTION
### Motivation
- Prevent an automatic restart loop triggered by a deferred startup scan that sets `pending_scan_on_start` and then triggers the auto-rescan restart logic.
- Ensure startup/deferred scans do not re-enable restart behavior or save a restart-triggering flag before the scan completes.

### Description
- Add an `allow_restart` parameter to `scan_driver_controls` with a default of `True` to allow callers to disable restart behavior when needed.
- Gate the existing rescan-restart logic behind `allow_restart` and `not self.pending_scan_on_start` to avoid restarting during a deferred startup scan.
- Call `scan_driver_controls` with `allow_restart=False` from `_perform_pending_scan` and preserve the previous `silent_if_unavailable` behavior.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a8bdce660832a86a8b24f134c3777)