### PR TITLE
Rename BOT timing profile labels to 'Rapid' and update probe messaging

### DIFF
--- a/FINALOK.py
+++ b/FINALOK.py
@@ -3046,7 +3046,7 @@ class ControlTab(tk.Frame):
             entry.config(state="readonly")
 
     def run_bot_timing_probe(self):
-        """Run a fast timing probe to suggest a stable BOT delay."""
+        """Run a fast timing probe to suggest a stable Rapid delay."""
 
         def _worker():
             try:
@@ -3070,7 +3070,7 @@ class ControlTab(tk.Frame):
             else:
                 msg = (
                     f"Minimal stable pulse detected at ~{suggested} ms.\n"
-                    "Apply this value to BOT/custom timings for reliable updates."
+                    "Apply this value to Rapid/Custom timings for reliable updates."
                 )
                 self.after(0, lambda: messagebox.showinfo("Probe Result", msg))
 
@@ -3860,7 +3860,7 @@ class GlobalTimingWindow(tk.Toplevel):
 
         tk.Radiobutton(
             profiles_frame,
-            text="🤖 BOT (experimental, near-zero delay)",
+            text="⚡ Rapid (experimental, near-zero delay)",
             variable=self.var_profile,
             value="bot",
             command=self._on_profile_change
@@ -3868,7 +3868,7 @@ class GlobalTimingWindow(tk.Toplevel):
 
         tk.Radiobutton(
             profiles_frame,
-            text="🤖 BOT Stable (fast, more reliable)",
+            text="⚡ Rapid Stable (fast, more reliable)",
             variable=self.var_profile,
             value="bot_safe",
             command=self._on_profile_change


### PR DESCRIPTION
### Motivation
- Replace the "BOT" wording with a friendlier, less ambiguous label to avoid misinterpretation of the timing profiles and make UI text clearer.

### Description
- Update UI text and related probe messaging in `FINALOK.py` by renaming the `bot` profile labels to `⚡ Rapid` and `⚡ Rapid Stable` and changing the `run_bot_timing_probe` docstring and info message to reference "Rapid/Custom" timings.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a98c8a93c832abcc008b21fea3b27)