### PR TITLE
Rename timing profile UI labels to friendlier 'Swift' and 'Steady'

### DIFF
--- a/FINALOK (2).py
+++ b/FINALOK (2).py
@@ -268,7 +268,7 @@ DEFAULT_OVERLAY_FEEDBACK = {
 
 # Timing profiles for input simulation (click-click timing)
 GLOBAL_TIMING = {
-    "profile": "bot",  # "aggressive", "casual", "relaxed", "custom", "bot", "bot_safe"
+    "profile": "bot",  # "aggressive", "casual", "relaxed", "custom", "bot" (Swift), "bot_safe" (Steady)
     # Custom profile settings:
     "press_min_ms": 60,
     "press_max_ms": 80,
@@ -588,7 +588,7 @@ def _compute_timing(is_float: bool = False) -> Tuple[float, float]:
             press_ms += random.uniform(-rng, rng)
             interval_ms += random.uniform(-rng, rng)
 
-    # Ensure minimum values, allowing extremely low latency for bot modes
+    # Ensure minimum values, allowing extremely low latency for swift modes
     if profile in {"bot", "bot_safe"}:
         min_value = 1
     else:
@@ -3725,7 +3725,7 @@ class GlobalTimingWindow(tk.Toplevel):
 
         tk.Radiobutton(
             profiles_frame,
-            text="🤖 BOT (experimental, near-zero delay)",
+            text="⚡ Swift (experimental, near-zero delay)",
             variable=self.var_profile,
             value="bot",
             command=self._on_profile_change
@@ -3733,7 +3733,7 @@ class GlobalTimingWindow(tk.Toplevel):
 
         tk.Radiobutton(
             profiles_frame,
-            text="🤖 BOT Stable (fast, more reliable)",
+            text="🌿 Steady (fast, more reliable)",
             variable=self.var_profile,
             value="bot_safe",
             command=self._on_profile_change


### PR DESCRIPTION
### Motivation

- Replace the wordy/ambiguous “bot” wording in the timing profile UI with friendlier labels to avoid misinterpretation while keeping existing behavior intact.

### Description

- Update UI radio labels to show `"⚡ Swift"` for the experimental near-zero delay mode and `"🌿 Steady"` for the fast-but-more-reliable mode while the internal profile keys remain `bot` and `bot_safe`.
- Clarify the `GLOBAL_TIMING` comment to map internal profile keys to the new friendly names and adjust an inline comment in `_compute_timing` from "bot modes" to "swift modes".
- Changes are limited to `FINALOK (2).py` and do not alter timing logic or profile keys; only user-facing labels and explanatory comments were modified.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a99f07118832aa21f008ea82bef3a)