### PR TITLE
Serialize IRSDK access during control scans and telemetry reads

### DIFF
--- a/dominant_control.py
+++ b/dominant_control.py
@@ -30,6 +30,7 @@ import subprocess
 import importlib
 import queue
 import numbers
+import contextlib
 from array import array
 import tempfile
 import wave
@@ -2441,14 +2442,19 @@ class GenericController:
         Returns:
             Current value or None if unavailable
         """
+        lock = getattr(self.app, "ir_lock", None)
+        cm = lock if lock is not None else contextlib.nullcontext()
         try:
-            if not getattr(self.ir, "is_initialized", False):
-                try:
-                    self.ir.startup()
-                except Exception:
+            with cm:
+                if not getattr(self.ir, "is_initialized", False):
+                    try:
+                        self.ir.startup()
+                    except Exception:
+                        return None
+                if getattr(self.ir, "is_connected", True) is False:
                     return None
-                    
-            value = self.ir[self.var_name]
+
+                value = self.ir[self.var_name]
             if value is None:
                 return None
                 
@@ -6840,16 +6846,17 @@ class iRacingControlApp:
 
             # Try to add all dc* variables from SDK
             try:
-                if hasattr(self.ir, "var_headers_dict") and self.ir.var_headers_dict:
-                    for key in self.ir.var_headers_dict.keys():
-                        if key.startswith("dc"):
-                            candidates.append(key)
-                elif hasattr(self.ir, "var_headers_names"):
-                    names = getattr(self.ir, "var_headers_names", None)
-                    if names:
-                        for key in names:
+                with self.ir_lock:
+                    if hasattr(self.ir, "var_headers_dict") and self.ir.var_headers_dict:
+                        for key in self.ir.var_headers_dict.keys():
                             if key.startswith("dc"):
                                 candidates.append(key)
+                    elif hasattr(self.ir, "var_headers_names"):
+                        names = getattr(self.ir, "var_headers_names", None)
+                        if names:
+                            for key in names:
+                                if key.startswith("dc"):
+                                    candidates.append(key)
             except Exception:
                 pass
 
@@ -6863,7 +6870,8 @@ class iRacingControlApp:
             try:
                 for candidate in candidates:
                     try:
-                        value = self.ir[candidate]
+                        with self.ir_lock:
+                            value = self.ir[candidate]
                     except Exception:
                         continue
 


### PR DESCRIPTION
### Motivation
- Recent behavior showed scans returning only a single control (often `dcBrakeBias`) and HUD monitor fields displaying `--`, consistent with concurrent unsynchronized reads from the iRacing SDK.
- The app performs SDK access from multiple threads (controllers, scanner worker), so SDK handle usage must be serialized to avoid intermittent empty/partial results.

### Description
- Synchronized controller telemetry reads by having `GenericController.read_telemetry()` use the app `ir_lock` when present and fall back to a no-op context via `contextlib.nullcontext()` when absent.
- Added an `is_connected` guard inside `GenericController.read_telemetry()` so controllers return `None` while the SDK is disconnected instead of attempting conversions.
- Serialized SDK header discovery and per-candidate reads in `_scan_driver_controls_worker()` by wrapping both the `var_headers_*` iteration and each variable access with `self.ir_lock`.
- Imported `contextlib` and applied the locking changes in `dominant_control.py` to ensure consistent, thread-safe SDK access.

### Testing
- Ran `python -m py_compile dominant_control.py` to verify the modified file compiles, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a9799bfc8321881f0f4a0ad51d81)